### PR TITLE
Add smart fill support for language fields

### DIFF
--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -31,7 +31,7 @@
     os:        ['operating_system', 'operatingsystem', '_os_', 'os_name', 'your_os', 'platform'],
     browser:   ['browser', 'useragent', 'user_agent', 'browsername'],
     version:   ['version', 'app_version', 'appversion', 'software_version', 'softwareversion'],
-    languages: ['language', 'languages', 'spoken_language', 'preferred_language', 'language_preference', 'primary_language'],
+    languages: ['spoken_language', 'preferred_language', 'language_preference', 'native_language', 'mother_tongue', 'languages_spoken'],
     pronouns: ['pronouns', 'pronoun', 'gender_pronoun', 'preferred_pronouns'],
     education: ['education', 'education_level', 'highest_education', 'degree', 'qualification', 'academic_level'],
     skills:    ['skill', 'expertise', 'technology', 'tech_stack', 'techstack', 'tools'],
@@ -63,6 +63,8 @@
         return type === 'sensitive' ? null : type;
       }
     }
+
+    if (isSpokenLanguageField(combined)) return 'languages';
 
     // Special case: bare 'os' as a whole word (e.g. name="os", id="os")
     if (/(?:^|_)os(?:_|$)/.test(combined)) return 'os';
@@ -99,6 +101,56 @@
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, ' ')
       .trim();
+  }
+
+  function isSpokenLanguageField(combined) {
+    const explicitPatterns = [
+      'spoken_language',
+      'preferred_language',
+      'language_preference',
+      'native_language',
+      'mother_tongue',
+      'languages_spoken'
+    ];
+
+    if (explicitPatterns.some(pattern => combined.includes(pattern))) {
+      return true;
+    }
+
+    if (!/(?:^|_)(language|languages)(?:_|$)/.test(combined)) {
+      return false;
+    }
+
+    const technicalPatterns = [
+      'coding_language',
+      'programming_language',
+      'query_language',
+      'language_style',
+      'primary_language',
+      'secondary_language',
+      'source_language',
+      'target_language',
+      'language_code',
+      'locale'
+    ];
+
+    return !technicalPatterns.some(pattern => combined.includes(pattern));
+  }
+
+  function matchesLanguageOption(optionNormalized, variation) {
+    const normalizedVariation = normalizeCandidateValue(variation);
+    if (!normalizedVariation) return false;
+
+    if (optionNormalized === normalizedVariation) {
+      return true;
+    }
+
+    if (/^[a-z]{2}$/.test(normalizedVariation)) {
+      return false;
+    }
+
+    return optionNormalized.includes(normalizedVariation) ||
+      normalizedVariation.includes(optionNormalized);
   }
 
   function createCandidateList(values, source, confidence) {
@@ -166,10 +218,7 @@
       if (optionEntries.length > 0) {
         const matched = optionEntries.find(option =>
           variations.some(variation => {
-            const normalizedVariation = normalizeCandidateValue(variation);
-            return option.normalized === normalizedVariation ||
-              option.normalized.includes(normalizedVariation) ||
-              normalizedVariation.includes(option.normalized);
+            return matchesLanguageOption(option.normalized, variation);
           })
         );
 

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -31,7 +31,10 @@
     os:        ['operating_system', 'operatingsystem', '_os_', 'os_name', 'your_os', 'platform'],
     browser:   ['browser', 'useragent', 'user_agent', 'browsername'],
     version:   ['version', 'app_version', 'appversion', 'software_version', 'softwareversion'],
-    skills:    ['skill', 'expertise', 'technology', 'tech_stack', 'techstack', 'languages', 'tools'],
+    languages: ['language', 'languages', 'spoken_language', 'preferred_language', 'language_preference', 'primary_language'],
+    pronouns: ['pronouns', 'pronoun', 'gender_pronoun', 'preferred_pronouns'],
+    education: ['education', 'education_level', 'highest_education', 'degree', 'qualification', 'academic_level'],
+    skills:    ['skill', 'expertise', 'technology', 'tech_stack', 'techstack', 'tools'],
     linkedin_url: ['linkedin'],
     github_url:   ['github'],
     timezone: ['timezone', 'time_zone'],
@@ -89,6 +92,104 @@
     if (/Firefox\//.test(ua)) { const v = ua.match(/Firefox\/([\d.]+)/); return `Firefox ${v ? v[1].split('.')[0] : ''}`.trim(); }
     if (/Safari\//.test(ua)) return 'Safari';
     return null;
+  }
+
+  function normalizeCandidateValue(value) {
+    return (value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+  }
+
+  function createCandidateList(values, source, confidence) {
+    const seen = new Set();
+    const candidates = [];
+
+    values.forEach(value => {
+      const clean = (value || '').trim();
+      const key = clean.toLowerCase();
+      if (!clean || seen.has(key)) return;
+      seen.add(key);
+      candidates.push({ value: clean, source, confidence });
+    });
+
+    return candidates;
+  }
+
+  function collectFieldOptions(element) {
+    if (!element) return [];
+
+    let rawOptions = [];
+
+    if (element.tagName?.toLowerCase() === 'select') {
+      rawOptions = Array.from(element.options || []).map(option => option.textContent || option.value || '');
+    } else if (element.list) {
+      rawOptions = Array.from(element.list.options || []).map(option => option.value || option.textContent || '');
+    }
+
+    return rawOptions
+      .map(option => option.trim())
+      .filter(option =>
+        option &&
+        !/^(select|choose|please select|pick one|--|n\/a)$/i.test(option)
+      );
+  }
+
+  function buildLanguageCandidates(element) {
+    const fieldOptions = collectFieldOptions(element);
+    const locales = Array.from(new Set(
+      [navigator.language, ...(navigator.languages || [])].filter(Boolean)
+    ));
+
+    const displayNames = typeof Intl.DisplayNames === 'function'
+      ? new Intl.DisplayNames(locales, { type: 'language' })
+      : null;
+
+    const optionEntries = fieldOptions.map(option => ({
+      value: option,
+      normalized: normalizeCandidateValue(option)
+    }));
+
+    const candidates = [];
+    const seen = new Set();
+
+    locales.forEach(locale => {
+      const languageCode = locale.split('-')[0];
+      const displayName = displayNames?.of(languageCode) || null;
+      const variations = [
+        displayName,
+        locale,
+        locale.replace('-', '_'),
+        languageCode
+      ].filter(Boolean);
+
+      if (optionEntries.length > 0) {
+        const matched = optionEntries.find(option =>
+          variations.some(variation => {
+            const normalizedVariation = normalizeCandidateValue(variation);
+            return option.normalized === normalizedVariation ||
+              option.normalized.includes(normalizedVariation) ||
+              normalizedVariation.includes(option.normalized);
+          })
+        );
+
+        if (matched && !seen.has(matched.value.toLowerCase())) {
+          seen.add(matched.value.toLowerCase());
+          candidates.push({ value: matched.value, source: 'Browser language preferences', confidence: 0.95 });
+        }
+
+        return;
+      }
+
+      const fallbackValue = displayName || locale;
+      const key = fallbackValue.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        candidates.push({ value: fallbackValue, source: 'Browser language preferences', confidence: 0.95 });
+      }
+    });
+
+    return candidates.slice(0, 3);
   }
 
   /**
@@ -150,6 +251,26 @@
           meta.isFormFill = true;
         }
       } catch (e) { /* unsupported */ }
+    }
+
+    if (fieldType === 'languages') {
+      const languageCandidates = buildLanguageCandidates(element);
+      if (languageCandidates.length > 0) {
+        meta.candidates.push(...languageCandidates);
+        meta.isFormFill = true;
+      }
+    }
+
+    if ((fieldType === 'pronouns' || fieldType === 'education') && element.tagName?.toLowerCase() === 'select') {
+      const optionCandidates = createCandidateList(
+        collectFieldOptions(element).slice(0, 3),
+        'Available form options',
+        0.65
+      );
+      if (optionCandidates.length > 0) {
+        meta.candidates.push(...optionCandidates);
+        meta.isFormFill = true;
+      }
     }
 
     // ── Tab-dependent types: mark isFormFill so service-worker uses

--- a/src/services/form-detector.js
+++ b/src/services/form-detector.js
@@ -8,6 +8,54 @@
  */
 
 class FormDetector {
+  _isSpokenLanguageField(combined) {
+    const explicitPatterns = [
+      'preferred language',
+      'spoken language',
+      'native language',
+      'language preference',
+      'mother tongue',
+      'languages spoken',
+      'preferred_language',
+      'spoken_language',
+      'native_language',
+      'language_preference',
+      'mother_tongue',
+      'languages_spoken'
+    ];
+
+    if (explicitPatterns.some(pattern => combined.includes(pattern))) {
+      return true;
+    }
+
+    if (!/(^|[\W_])(language|languages)([\W_]|$)/.test(combined)) {
+      return false;
+    }
+
+    const technicalPatterns = [
+      'coding language',
+      'programming language',
+      'query language',
+      'language style',
+      'primary language',
+      'secondary language',
+      'source language',
+      'target language',
+      'language code',
+      'coding_language',
+      'programming_language',
+      'query_language',
+      'language_style',
+      'primary_language',
+      'secondary_language',
+      'source_language',
+      'target_language',
+      'language_code',
+      'locale'
+    ];
+
+    return !technicalPatterns.some(pattern => combined.includes(pattern));
+  }
 
   /**
    * Analyse a focused input element and return field metadata + smart fill candidates.
@@ -63,7 +111,7 @@ class FormDetector {
     if (/(github|git[_\s-]hub)/.test(combined)) return 'github_url';
     if (/(website|portfolio|personal[_\s-]?site|homepage|url|link)/.test(combined)) return 'website';
     if (/(years[_\s]?of[_\s]?exp|experience[_\s]?years|yoe)/.test(combined)) return 'experience_years';
-    if (/(preferred[_\s-]?language|spoken[_\s-]?language|languages?)/.test(combined)) return 'languages';
+    if (this._isSpokenLanguageField(combined)) return 'languages';
     if (/(pronouns?|preferred[_\s-]?pronouns?)/.test(combined)) return 'pronouns';
     if (/(education|education[_\s-]?level|highest[_\s-]?education|degree|qualification|academic[_\s-]?level)/.test(combined)) return 'education';
     if (/(skill|expertise|technology|tech[_\s]?stack|tools)/.test(combined)) return 'skills';

--- a/src/services/form-detector.js
+++ b/src/services/form-detector.js
@@ -307,7 +307,12 @@ class FormDetector {
       : null;
 
     return locales
-      .map(locale => displayNames?.of(locale.split('-')[0]) || locale)
+      .map(locale => {
+        const code = locale.split('-')[0];
+        const displayName = displayNames?.of(code);
+        if (!displayName || /^[a-z]{2}$/i.test(displayName)) return null;
+        return displayName;
+      })
       .filter((value, index, all) => value && all.indexOf(value) === index)
       .slice(0, 3);
   }

--- a/src/services/form-detector.js
+++ b/src/services/form-detector.js
@@ -63,7 +63,10 @@ class FormDetector {
     if (/(github|git[_\s-]hub)/.test(combined)) return 'github_url';
     if (/(website|portfolio|personal[_\s-]?site|homepage|url|link)/.test(combined)) return 'website';
     if (/(years[_\s]?of[_\s]?exp|experience[_\s]?years|yoe)/.test(combined)) return 'experience_years';
-    if (/(skill|expertise|technology|tech[_\s]?stack|languages|tools)/.test(combined)) return 'skills';
+    if (/(preferred[_\s-]?language|spoken[_\s-]?language|languages?)/.test(combined)) return 'languages';
+    if (/(pronouns?|preferred[_\s-]?pronouns?)/.test(combined)) return 'pronouns';
+    if (/(education|education[_\s-]?level|highest[_\s-]?education|degree|qualification|academic[_\s-]?level)/.test(combined)) return 'education';
+    if (/(skill|expertise|technology|tech[_\s]?stack|tools)/.test(combined)) return 'skills';
    
     // ── Support / bug report ─────────────────────────────────────────────────
     if (/(os|operating[_\s]?system|platform)/.test(combined)) return 'os';
@@ -133,6 +136,14 @@ class FormDetector {
           const skills = this._extractSkillsFromGitHub(ghTab.title);
           if (skills) candidates.push({ value: skills, source: 'GitHub tab', confidence: 0.7 });
         }
+        break;
+      }
+
+      case 'languages': {
+        const preferredLanguages = this._detectLanguages();
+        preferredLanguages.forEach(language => {
+          candidates.push({ value: language, source: 'Browser language preferences', confidence: 0.95 });
+        });
         break;
       }
 
@@ -236,6 +247,21 @@ class FormDetector {
     // GitHub profile: "username (Full Name) · GitHub" — not much to extract.
     // Return null and let the AI build skills suggestions from history instead.
     return null;
+  }
+
+  _detectLanguages() {
+    const locales = Array.from(new Set(
+      [navigator.language, ...(navigator.languages || [])].filter(Boolean)
+    ));
+
+    const displayNames = typeof Intl.DisplayNames === 'function'
+      ? new Intl.DisplayNames(locales, { type: 'language' })
+      : null;
+
+    return locales
+      .map(locale => displayNames?.of(locale.split('-')[0]) || locale)
+      .filter((value, index, all) => value && all.indexOf(value) === index)
+      .slice(0, 3);
   }
 
   _detectOS() {

--- a/src/services/groq-service.js
+++ b/src/services/groq-service.js
@@ -40,7 +40,10 @@ class GroqService {
       console.log('Session intent:', context.sessionIntent?.sessionSummary || 'none');
       console.log('Form field:', context.fieldMeta?.fieldType || 'none');
 
-      return await this.callWithRetry(apiKey, prompt, systemPrompt);
+      const result = await this.callWithRetry(apiKey, prompt, systemPrompt);
+      return context.fieldMeta?.fieldType
+        ? { ...result, isFormFill: true }
+        : result;
     } catch (error) {
       console.error('Groq API error:', error);
       return { reason: 'Error generating suggestions', suggestions: [], error: error.message };


### PR DESCRIPTION
## Summary
Adds support for more README-requested form field types and improves smart fill for language fields.

## Changes
- classify languages, pronouns, and education separately instead of folding languages into skills
- smart-fill language fields from browser language preferences
- match browser languages against select and datalist options when available
- keep form-field AI responses on the smart-fill UI path

## Validation
- ran 
ode --check on:
  - src/content/content-script.js
  - src/services/form-detector.js
  - src/services/groq-service.js

## Notes
This follows the project README contribution direction around expanding form field coverage.