### PR TITLE
Stop loading overlay when extension is disabled

### DIFF
--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -14,6 +14,7 @@
   let debounceTimer = null;
   let lastInputValue = '';
   let isAddressBar = false;
+  let extensionEnabled = true;
 
   // Sites where the extension should stay completely silent
   const BLOCKED_DOMAINS = [
@@ -196,11 +197,22 @@
     return BLOCKED_DOMAINS.some(domain => host.includes(domain));
   }
 
-  function initialize() {
+  async function loadExtensionState() {
+    try {
+      const stored = await chrome.storage.local.get('extensionEnabled');
+      extensionEnabled = stored.extensionEnabled ?? true;
+    } catch (error) {
+      console.error('Failed to load extension state:', error);
+      extensionEnabled = true;
+    }
+  }
+
+  async function initialize() {
     if (isBlockedDomain()) {
       console.log('AI Context Assistant: disabled on', window.location.hostname);
       return;
     }
+    await loadExtensionState();
     setupInputTracking();
     setupMessageListener();
     createSuggestionOverlay();
@@ -405,6 +417,11 @@
 
   function debouncedGenerateSuggestions(input, value) {
     clearTimeout(debounceTimer);
+    if (!extensionEnabled) {
+      hideSuggestion();
+      currentSuggestions = [];
+      return;
+    }
     showSuggestionLoading(input);
     const delay = isAddressBar ? 400 : 500;
     debounceTimer = setTimeout(() => generateSuggestions(input, value), delay);
@@ -412,6 +429,12 @@
 
   async function generateSuggestions(input, value) {
     try {
+      if (!extensionEnabled) {
+        hideSuggestion();
+        currentSuggestions = [];
+        return;
+      }
+
       // Build form field metadata from the focused element
       const fieldMeta = buildFieldMeta(input);
 
@@ -625,7 +648,10 @@
       case 'getActiveInput': return getActiveInput();
       case 'insertSuggestion': return insertSuggestion(request.data.text);
       case 'toggleExtension':
-        if (!request.data.enabled) hideSuggestion();
+        extensionEnabled = request.data.enabled ?? true;
+        clearTimeout(debounceTimer);
+        currentSuggestions = [];
+        if (!extensionEnabled) hideSuggestion();
         return { success: true };
       default: throw new Error(`Unknown action: ${request.action}`);
     }
@@ -671,6 +697,6 @@
     }
   }
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initialize);
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', () => initialize());
   else initialize();
 })();


### PR DESCRIPTION
Closes #18

## Summary
Prevents the content script from showing the temporary "Thinking..." overlay when the extension has been disabled.

## Changes
- load the stored extensionEnabled state when the content script initializes
- short-circuit debounced suggestion generation when the extension is off
- short-circuit request dispatch when the extension is off
- clear pending debounce timers and hide the overlay immediately when the popup toggle disables the extension

## Validation
- ran node --check src/content/content-script.js

## Why this fixes the bug
The service worker already avoids API calls when disabled, but the content script was showing the loading overlay before that check. This moves the disabled-state gate into the content script so the overlay never appears in the first place.
