### PR TITLE
Fix overlay positioning on scrolled pages

### DIFF
--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -329,6 +329,13 @@
       }
     }, true);
 
+    window.addEventListener('scroll', () => {
+      if (suggestionOverlay?.style.display === 'block' && currentInput) positionOverlay(currentInput);
+    }, true);
+    window.addEventListener('resize', () => {
+      if (suggestionOverlay?.style.display === 'block' && currentInput) positionOverlay(currentInput);
+    });
+
     if (window.location.href.includes('claude.ai')) setupClaudeInputDetection();
   }
 
@@ -561,6 +568,7 @@
   function positionOverlay(input) {
     if (!suggestionOverlay || !input) return;
 
+    const anchorRect = getOverlayAnchorRect(input);
     const rect = input.getBoundingClientRect();
     const spacing = isAddressBar ? 14 : 10;
     const viewportPadding = 12;
@@ -572,12 +580,12 @@
     suggestionOverlay.style.width = `${overlayWidth}px`;
 
     const overlayHeight = suggestionOverlay.offsetHeight || 48;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - anchorRect.bottom;
+    const spaceAbove = anchorRect.top;
 
-    let top = rect.bottom + spacing;
+    let top = anchorRect.bottom + spacing;
     if (spaceBelow < overlayHeight + viewportPadding && spaceAbove > overlayHeight + viewportPadding) {
-      top = Math.max(viewportPadding, rect.top - overlayHeight - spacing);
+      top = Math.max(viewportPadding, anchorRect.top - overlayHeight - spacing);
     }
 
     const maxLeft = window.innerWidth - overlayWidth - viewportPadding;
@@ -588,6 +596,98 @@
 
     suggestionOverlay.style.left = `${left}px`;
     suggestionOverlay.style.top = `${top}px`;
+  }
+
+  function getOverlayAnchorRect(input) {
+    if (!input) return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 };
+
+    const tagName = input.tagName?.toLowerCase();
+    if (tagName === 'textarea') {
+      return getTextareaCaretRect(input);
+    }
+
+    if (input.contentEditable === 'true' || input.getAttribute('role') === 'textbox') {
+      const selection = window.getSelection();
+      if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0).cloneRange();
+        range.collapse(false);
+        const rect = range.getClientRects()[0] || range.getBoundingClientRect();
+        if (rect && (rect.width || rect.height || rect.top || rect.left)) return rect;
+      }
+    }
+
+    return input.getBoundingClientRect();
+  }
+
+  function getTextareaCaretRect(textarea) {
+    const rect = textarea.getBoundingClientRect();
+    const selectionStart = typeof textarea.selectionStart === 'number'
+      ? textarea.selectionStart
+      : textarea.value.length;
+    const computed = window.getComputedStyle(textarea);
+    const mirror = document.createElement('div');
+    const properties = [
+      'boxSizing',
+      'width',
+      'paddingTop',
+      'paddingRight',
+      'paddingBottom',
+      'paddingLeft',
+      'borderTopWidth',
+      'borderRightWidth',
+      'borderBottomWidth',
+      'borderLeftWidth',
+      'fontFamily',
+      'fontSize',
+      'fontWeight',
+      'fontStyle',
+      'lineHeight',
+      'letterSpacing',
+      'textTransform',
+      'textIndent',
+      'textAlign',
+      'whiteSpace',
+      'wordBreak',
+      'overflowWrap',
+      'tabSize'
+    ];
+
+    mirror.style.position = 'fixed';
+    mirror.style.top = '0';
+    mirror.style.left = '-9999px';
+    mirror.style.visibility = 'hidden';
+    mirror.style.pointerEvents = 'none';
+    mirror.style.whiteSpace = 'pre-wrap';
+    mirror.style.wordWrap = 'break-word';
+    mirror.style.overflow = 'hidden';
+
+    for (const property of properties) {
+      mirror.style[property] = computed[property];
+    }
+
+    const beforeCaret = textarea.value.slice(0, selectionStart);
+    const afterCaret = textarea.value.slice(selectionStart);
+    mirror.textContent = beforeCaret;
+
+    const marker = document.createElement('span');
+    marker.textContent = afterCaret.charAt(0) || '\u200b';
+    mirror.appendChild(marker);
+    document.body.appendChild(mirror);
+
+    const lineHeight = Number.parseFloat(computed.lineHeight) || (Number.parseFloat(computed.fontSize) * 1.4) || 20;
+    const top = rect.top + marker.offsetTop - textarea.scrollTop;
+    const bottom = top + lineHeight;
+
+    mirror.remove();
+
+    return {
+      top,
+      bottom,
+      left: rect.left,
+      right: rect.right,
+      width: rect.width,
+      height: lineHeight
+    };
   }
 
   function updateSuggestionDisplay() {

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -498,15 +498,7 @@
 
     if (!suggestionOverlay) return;
 
-    const rect = input.getBoundingClientRect();
-    let top = rect.bottom + window.scrollY + 10;
-    const left = rect.left + window.scrollX;
-    if (isAddressBar) top = rect.bottom + window.scrollY + 14;
-
     suggestionOverlay.style.display = 'block';
-    suggestionOverlay.style.left = `${left}px`;
-    suggestionOverlay.style.top = `${top}px`;
-    suggestionOverlay.style.width = `${Math.max(rect.width, 320)}px`;
 
     // Counter pill
     const counter = currentSuggestions.length > 1
@@ -545,18 +537,13 @@
       <div style="font-size:10.5px;color:rgba(255,255,255,0.38);font-weight:400;">Tab to accept${currentSuggestions.length > 1 ? ' · ↑↓ to cycle' : ''}</div>
       ${caption}
     `;
+
+    positionOverlay(input);
   }
 
   function showSuggestionLoading(input) {
     if (!suggestionOverlay) return;
-    const rect = input.getBoundingClientRect();
-    let top = rect.bottom + window.scrollY + 10;
-    const left = rect.left + window.scrollX;
-    if (isAddressBar) top = rect.bottom + window.scrollY + 14;
-
     suggestionOverlay.style.display = 'block';
-    suggestionOverlay.style.left = `${left}px`;
-    suggestionOverlay.style.top = `${top}px`;
     suggestionOverlay.innerHTML = `
       <div style="display:flex;align-items:center;gap:8px;font-size:12px;color:rgba(255,255,255,0.55);font-weight:400;">
         <span style="display:inline-flex;gap:3px;align-items:center;">
@@ -567,6 +554,40 @@
         Thinking…
       </div>
     `;
+
+    positionOverlay(input);
+  }
+
+  function positionOverlay(input) {
+    if (!suggestionOverlay || !input) return;
+
+    const rect = input.getBoundingClientRect();
+    const spacing = isAddressBar ? 14 : 10;
+    const viewportPadding = 12;
+    const overlayWidth = Math.min(
+      Math.max(rect.width, 320),
+      window.innerWidth - (viewportPadding * 2)
+    );
+
+    suggestionOverlay.style.width = `${overlayWidth}px`;
+
+    const overlayHeight = suggestionOverlay.offsetHeight || 48;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+
+    let top = rect.bottom + spacing;
+    if (spaceBelow < overlayHeight + viewportPadding && spaceAbove > overlayHeight + viewportPadding) {
+      top = Math.max(viewportPadding, rect.top - overlayHeight - spacing);
+    }
+
+    const maxLeft = window.innerWidth - overlayWidth - viewportPadding;
+    const left = Math.min(
+      Math.max(viewportPadding, rect.left),
+      Math.max(viewportPadding, maxLeft)
+    );
+
+    suggestionOverlay.style.left = `${left}px`;
+    suggestionOverlay.style.top = `${top}px`;
   }
 
   function updateSuggestionDisplay() {


### PR DESCRIPTION
Closes #23

## Summary
Fixes overlay placement on GitHub and other scrolled pages by positioning the suggestion overlay relative to the viewport instead of the full document.

## Changes
- stop adding window scroll offsets to a position: fixed overlay
- centralize overlay placement in a positionOverlay helper used by both loading and suggestion states
- clamp the overlay horizontally within the viewport
- flip the overlay above the input when there is not enough room below

## Validation
- ran node --check src/content/content-script.js

## Why this fixes the bug
The overlay uses position: fixed, but the previous placement code added window.scrollX and window.scrollY as if it were page-positioned. On scrolled pages like GitHub issue forms, that pushed the smart-fill UI away from the active textarea and toward the bottom of the screen.
