### PR TITLE
fix: blocked domains

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -4,17 +4,17 @@
  * + Smart Form-Fill Suggestions
  */
 
-import configManager from '../config/config-manager.js';
-import groqService from '../services/groq-service.js';
-import contextCollector from '../services/context-collector.js';
-import sessionTracker from '../services/session-tracker.js';
-import formDetector from '../services/form-detector.js';
+import configManager from "../config/config-manager.js";
+import groqService from "../services/groq-service.js";
+import contextCollector from "../services/context-collector.js";
+import sessionTracker from "../services/session-tracker.js";
+import formDetector from "../services/form-detector.js";
 
 chrome.runtime.onInstalled.addListener(async () => {
-  console.log('AI Context Assistant installed');
+  console.log("AI Context Assistant installed");
   await configManager.initialize();
-  chrome.action.setBadgeText({ text: '' });
-  chrome.action.setBadgeBackgroundColor({ color: '#4A90E2' });
+  chrome.action.setBadgeText({ text: "" });
+  chrome.action.setBadgeBackgroundColor({ color: "#4A90E2" });
 });
 
 chrome.runtime.onStartup.addListener(async () => {
@@ -24,8 +24,8 @@ chrome.runtime.onStartup.addListener(async () => {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   handleMessage(request, sender)
     .then(sendResponse)
-    .catch(error => {
-      console.error('Message error:', error);
+    .catch((error) => {
+      console.error("Message error:", error);
       sendResponse({ success: false, error: error.message });
     });
   return true;
@@ -35,43 +35,44 @@ async function handleMessage(request, sender) {
   const { action, data } = request;
 
   switch (action) {
-    case 'generateSuggestions':
+    case "generateSuggestions":
       return await generateSuggestions(data);
 
-    case 'getConfig':
+    case "getConfig":
       await configManager.initialize();
       return {
         success: true,
         config: {
           isConfigured: configManager.isConfigured(),
-          model: configManager.get('model'),
-          enableHistoryTracking: configManager.get('enableHistoryTracking'),
-          enableTabAnalysis: configManager.get('enableTabAnalysis'),
-          enableAiChatMode: configManager.get('enableAiChatMode')
-        }
+          blockedDomains: configManager.get("blockedDomains"),
+          model: configManager.get("model"),
+          enableHistoryTracking: configManager.get("enableHistoryTracking"),
+          enableTabAnalysis: configManager.get("enableTabAnalysis"),
+          enableAiChatMode: configManager.get("enableAiChatMode"),
+        },
       };
 
-    case 'setApiKey':
+    case "setApiKey":
       await configManager.initialize();
       await configManager.setApiKey(data.apiKey);
       return { success: true };
 
-    case 'updateConfig':
+    case "updateConfig":
       await configManager.initialize();
       await configManager.update(data.updates);
       return { success: true };
 
-    case 'testConnection':
+    case "testConnection":
       await configManager.initialize();
       const isConnected = await groqService.testConnection();
       return { success: isConnected };
 
-    case 'clearConfig':
+    case "clearConfig":
       await configManager.clear();
       await sessionTracker.clearSession();
       return { success: true };
 
-    case 'getSessionIntent':
+    case "getSessionIntent":
       return { success: true, intent: await sessionTracker.getIntentContext() };
 
     default:
@@ -82,11 +83,15 @@ async function handleMessage(request, sender) {
 async function generateSuggestions(data) {
   try {
     // Check if extension is enabled
-    const stored = await chrome.storage.local.get('extensionEnabled');
+    const stored = await chrome.storage.local.get("extensionEnabled");
     const extensionEnabled = stored.extensionEnabled ?? true;
 
     if (!extensionEnabled) {
-      return { success: true, reason: 'Extension is disabled', suggestions: [] };
+      return {
+        success: true,
+        reason: "Extension is disabled",
+        suggestions: [],
+      };
     }
 
     if (!configManager.initialized) {
@@ -94,22 +99,39 @@ async function generateSuggestions(data) {
     }
 
     if (!configManager.isConfigured()) {
-      return { success: false, error: 'Groq API key not configured', suggestions: [] };
+      return {
+        success: false,
+        error: "Groq API key not configured",
+        suggestions: [],
+      };
     }
 
     const fullContext = await contextCollector.collectContext();
 
     const mergedContext = {
       ...fullContext,
-      active_input_text: data.context?.active_input_text || fullContext.active_input_text,
+      active_input_text:
+        data.context?.active_input_text || fullContext.active_input_text,
       page_type: data.context?.page_type || fullContext.page_type,
-      current_page: { ...fullContext.current_page, ...(data.context?.current_page || {}) },
-      sessionIntent: await sessionTracker.getIntentContext()
+      current_page: {
+        ...fullContext.current_page,
+        ...(data.context?.current_page || {}),
+      },
+      sessionIntent: await sessionTracker.getIntentContext(),
     };
 
     if (mergedContext.active_input_text && data.fieldName) {
-      if (contextCollector.isSensitiveInput(mergedContext.active_input_text, data.fieldName)) {
-        return { success: true, reason: 'Sensitive input detected', suggestions: [] };
+      if (
+        contextCollector.isSensitiveInput(
+          mergedContext.active_input_text,
+          data.fieldName,
+        )
+      ) {
+        return {
+          success: true,
+          reason: "Sensitive input detected",
+          suggestions: [],
+        };
       }
     }
 
@@ -120,27 +142,32 @@ async function generateSuggestions(data) {
     if (fieldMeta?.fieldType) {
       const detectorMeta = formDetector.analyzeField(
         {
-          name: '',      // already classified by content-script
-          id: '',
-          placeholder: fieldMeta.fieldLabel || '',
-          autocomplete: '',
-          label: fieldMeta.fieldLabel || '',
-          type: 'text',
-          pageUrl: mergedContext.current_page?.url || '',
-          pageTitle: fieldMeta.pageTitle || mergedContext.current_page?.title || ''
+          name: "", // already classified by content-script
+          id: "",
+          placeholder: fieldMeta.fieldLabel || "",
+          autocomplete: "",
+          label: fieldMeta.fieldLabel || "",
+          type: "text",
+          pageUrl: mergedContext.current_page?.url || "",
+          pageTitle:
+            fieldMeta.pageTitle || mergedContext.current_page?.title || "",
         },
         mergedContext.active_tabs || [],
-        fieldMeta.fieldType  // pass pre-classified type — skip re-classification
+        fieldMeta.fieldType, // pass pre-classified type — skip re-classification
       );
 
       if (detectorMeta?.candidates?.length > 0) {
         // Merge: keep existing local candidates (higher confidence) and append tab-based ones
-        const existingValues = new Set((fieldMeta.candidates || []).map(c => c.value));
-        const newCandidates = detectorMeta.candidates.filter(c => !existingValues.has(c.value));
+        const existingValues = new Set(
+          (fieldMeta.candidates || []).map((c) => c.value),
+        );
+        const newCandidates = detectorMeta.candidates.filter(
+          (c) => !existingValues.has(c.value),
+        );
         fieldMeta = {
           ...fieldMeta,
           candidates: [...(fieldMeta.candidates || []), ...newCandidates],
-          isFormFill: true
+          isFormFill: true,
         };
       }
     }
@@ -151,29 +178,40 @@ async function generateSuggestions(data) {
 
     // Record the query into the session tracker AFTER generating suggestions
     if (mergedContext.active_input_text) {
-      await sessionTracker.recordQuery(mergedContext.active_input_text, result.suggestions);
+      await sessionTracker.recordQuery(
+        mergedContext.active_input_text,
+        result.suggestions,
+      );
     }
 
-    if (configManager.get('enableHistoryTracking') && mergedContext.active_input_text) {
-      await storePastSearch(mergedContext.active_input_text, result.suggestions);
+    if (
+      configManager.get("enableHistoryTracking") &&
+      mergedContext.active_input_text
+    ) {
+      await storePastSearch(
+        mergedContext.active_input_text,
+        result.suggestions,
+      );
     }
 
     return { success: true, ...result };
   } catch (error) {
-    console.error('Error:', error);
+    console.error("Error:", error);
     return { success: false, error: error.message, suggestions: [] };
   }
 }
 
 async function storePastSearch(query, suggestions) {
   try {
-    const stored = await chrome.storage.local.get('pastSearches');
+    const stored = await chrome.storage.local.get("pastSearches");
     const pastSearches = stored.pastSearches || [];
     pastSearches.unshift({ query, suggestions, timestamp: Date.now() });
     await chrome.storage.local.set({ pastSearches: pastSearches.slice(0, 50) });
   } catch (error) {
-    console.error('Storage error:', error);
+    console.error("Storage error:", error);
   }
 }
 
-console.log('Service worker loaded - Groq Cloud Edition + Session Tracking + Form Fill');
+console.log(
+  "Service worker loaded - Groq Cloud Edition + Session Tracking + Form Fill",
+);

--- a/src/config/config-manager.js
+++ b/src/config/config-manager.js
@@ -12,11 +12,12 @@ class ConfigManager {
     if (this.initialized) return;
 
     try {
-      const stored = await chrome.storage.local.get(['groqApiKey', 'config']);
-      
+      const stored = await chrome.storage.local.get(["groqApiKey", "config"]);
+
       this.config = {
         groqApiKey: stored.groqApiKey || null,
-        model: stored.config?.model || 'llama-3.1-8b-instant',
+        model: stored.config?.model || "llama-3.1-8b-instant",
+        blockedDomains: stored.config?.blockedDomains || ["linkedin.com"],
         maxTokens: stored.config?.maxTokens || 150,
         temperature: stored.config?.temperature || 0.3,
         enableHistoryTracking: stored.config?.enableHistoryTracking ?? true,
@@ -24,30 +25,40 @@ class ConfigManager {
         enableAiChatMode: stored.config?.enableAiChatMode ?? true,
         debugMode: stored.config?.debugMode || false,
         blockedSensitiveFields: stored.config?.blockedSensitiveFields || [
-          'password', 'passwd', 'pwd', 'credit-card', 'creditcard', 'ssn', 'bank', 'pin', 'cvv', 'api-key', 'token'
-        ]
+          "password",
+          "passwd",
+          "pwd",
+          "credit-card",
+          "creditcard",
+          "ssn",
+          "bank",
+          "pin",
+          "cvv",
+          "api-key",
+          "token",
+        ],
       };
 
       this.initialized = true;
     } catch (error) {
-      console.error('Config initialization failed:', error);
-      throw new Error('Configuration initialization failed');
+      console.error("Config initialization failed:", error);
+      throw new Error("Configuration initialization failed");
     }
   }
 
   getApiKey() {
     if (!this.config?.groqApiKey) {
-      throw new Error('Groq API key not configured');
+      throw new Error("Groq API key not configured");
     }
     return this.config.groqApiKey;
   }
 
   async setApiKey(apiKey) {
-    if (!apiKey || typeof apiKey !== 'string') {
-      throw new Error('Invalid API key');
+    if (!apiKey || typeof apiKey !== "string") {
+      throw new Error("Invalid API key");
     }
 
-    if (!apiKey.startsWith('gsk_')) {
+    if (!apiKey.startsWith("gsk_")) {
       throw new Error('Invalid format. Groq keys start with "gsk_"');
     }
 
@@ -60,7 +71,7 @@ class ConfigManager {
   }
 
   async update(updates) {
-    const currentConfig = await chrome.storage.local.get('config');
+    const currentConfig = await chrome.storage.local.get("config");
     const newConfig = { ...currentConfig.config, ...updates };
     await chrome.storage.local.set({ config: newConfig });
     this.config = { ...this.config, ...updates };
@@ -72,9 +83,11 @@ class ConfigManager {
 
   isSensitiveField(fieldName) {
     if (!fieldName) return false;
-    const normalized = fieldName.toLowerCase().replace(/[_\s-]/g, '');
-    const blockedFields = this.config.blockedSensitiveFields.map(f => f.toLowerCase().replace(/[_\s-]/g, ''));
-    return blockedFields.some(blocked => normalized.includes(blocked));
+    const normalized = fieldName.toLowerCase().replace(/[_\s-]/g, "");
+    const blockedFields = this.config.blockedSensitiveFields.map((f) =>
+      f.toLowerCase().replace(/[_\s-]/g, ""),
+    );
+    return blockedFields.some((blocked) => normalized.includes(blocked));
   }
 
   async clear() {

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -3,7 +3,28 @@
  * + Smart Form-Fill detection
  * + Session-aware suggestion labels
  */
-import configManager from "../config/config-manager.js";
+
+const configManager = {
+  async get(key, defaultValue = null) {
+    try {
+      const syncResult = await chrome.storage.sync.get(key);
+      if (syncResult[key] !== undefined) {
+        return syncResult[key];
+      }
+      const localResult = await chrome.storage.local.get(key);
+      if (localResult[key] !== undefined) {
+        return localResult[key];
+      }
+    } catch (error) {
+      console.warn("Failed to read config from extension storage:", error);
+    }
+    return defaultValue;
+  },
+  async getBlockedDomains() {
+    const blockedDomains = await this.get("blockedDomains", []);
+    return Array.isArray(blockedDomains) ? blockedDomains : [];
+  },
+};
 
 (function () {
   "use strict";
@@ -338,7 +359,12 @@ import configManager from "../config/config-manager.js";
   function isBlockedDomain(blockedDomains) {
     if (!Array.isArray(blockedDomains)) return false;
     const host = window.location.hostname.toLowerCase();
-    return blockedDomains.some((domain) => host.includes(domain));
+    return blockedDomains.some((domain) => {
+      if (typeof domain !== "string") return false;
+      const normalizedDomain = domain.trim().toLowerCase().replace(/^\.+/, "");
+      if (!normalizedDomain) return false;
+      return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+    });
   }
 
   async function initialize() {

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -3,91 +3,195 @@
  * + Smart Form-Fill detection
  * + Session-aware suggestion labels
  */
+import configManager from "../config/config-manager.js";
 
-(function() {
-  'use strict';
-
+(function () {
+  "use strict";
   let currentInput = null;
   let suggestionOverlay = null;
   let currentSuggestions = [];
   let activeSuggestionIndex = 0;
   let debounceTimer = null;
-  let lastInputValue = '';
+  let lastInputValue = "";
   let isAddressBar = false;
-
-  // Sites where the extension should stay completely silent
-  const BLOCKED_DOMAINS = [
-    'linkedin.com'
-  ];
 
   // ── Form-fill detector (inline, no import needed in content scripts) ────────
   const FORM_FIELD_PATTERNS = {
-    // Sensitive must be checked 
-    sensitive: ['password', 'passwd', 'pwd', 'credit', 'card', 'cvv', 'cvc', 'ssn', 'bank', 'pin', 'otp', 'auth', 'token', 'secret', 'email', 'e_mail', 'mail'],
-    job_title: ['job_title', 'jobtitle', 'position', 'role', 'designation', 'occupation', 'job_role'],
+    // Sensitive must be checked
+    sensitive: [
+      "password",
+      "passwd",
+      "pwd",
+      "credit",
+      "card",
+      "cvv",
+      "cvc",
+      "ssn",
+      "bank",
+      "pin",
+      "otp",
+      "auth",
+      "token",
+      "secret",
+      "email",
+      "e_mail",
+      "mail",
+    ],
+    job_title: [
+      "job_title",
+      "jobtitle",
+      "position",
+      "role",
+      "designation",
+      "occupation",
+      "job_role",
+    ],
     // 'title' alone is too broad (page titles, article titles etc.) — only match when combined
-    company:   ['company', 'employer', 'organisation', 'organization', 'workplace', 'firm', 'companyname'],
+    company: [
+      "company",
+      "employer",
+      "organisation",
+      "organization",
+      "workplace",
+      "firm",
+      "companyname",
+    ],
     // ' os ' with spaces won't match after space→_ normalization; use '_os_', 'os_name', or standalone 'os' at word boundary
-    os:        ['operating_system', 'operatingsystem', '_os_', 'os_name', 'your_os', 'platform'],
-    browser:   ['browser', 'useragent', 'user_agent', 'browsername'],
-    version:   ['version', 'app_version', 'appversion', 'software_version', 'softwareversion'],
-    skills:    ['skill', 'expertise', 'technology', 'tech_stack', 'techstack', 'languages', 'tools'],
-    linkedin_url: ['linkedin'],
-    github_url:   ['github'],
-    timezone: ['timezone', 'time_zone'],
-    website:      ['website', 'portfolio', 'personal_site', 'homepage', 'personal_url'],
-    experience_years: ['years_of_exp', 'yearsofexp', 'experience_years', 'yoe', 'years_experience'],
-    issue_subject:     ['subject', 'issue_title', 'issuetitle', 'ticket_title', 'tickettitle', 'summary'],
-    issue_description: ['description', 'details', 'body', 'explain', 'steps_to_reproduce', 'reproduce']
+    os: [
+      "operating_system",
+      "operatingsystem",
+      "_os_",
+      "os_name",
+      "your_os",
+      "platform",
+    ],
+    browser: ["browser", "useragent", "user_agent", "browsername"],
+    version: [
+      "version",
+      "app_version",
+      "appversion",
+      "software_version",
+      "softwareversion",
+    ],
+    skills: [
+      "skill",
+      "expertise",
+      "technology",
+      "tech_stack",
+      "techstack",
+      "languages",
+      "tools",
+    ],
+    linkedin_url: ["linkedin"],
+    github_url: ["github"],
+    timezone: ["timezone", "time_zone"],
+    website: [
+      "website",
+      "portfolio",
+      "personal_site",
+      "homepage",
+      "personal_url",
+    ],
+    experience_years: [
+      "years_of_exp",
+      "yearsofexp",
+      "experience_years",
+      "yoe",
+      "years_experience",
+    ],
+    issue_subject: [
+      "subject",
+      "issue_title",
+      "issuetitle",
+      "ticket_title",
+      "tickettitle",
+      "summary",
+    ],
+    issue_description: [
+      "description",
+      "details",
+      "body",
+      "explain",
+      "steps_to_reproduce",
+      "reproduce",
+    ],
   };
 
   function classifyField(element) {
     if (!element) return null;
     const combined = [
-      element.name, element.id, element.placeholder,
-      element.getAttribute('autocomplete'),
-      element.getAttribute('aria-label'),
-      element.type
-    ].join(' ').toLowerCase().replace(/[-\s]/g, '_');
+      element.name,
+      element.id,
+      element.placeholder,
+      element.getAttribute("autocomplete"),
+      element.getAttribute("aria-label"),
+      element.type,
+    ]
+      .join(" ")
+      .toLowerCase()
+      .replace(/[-\s]/g, "_");
 
     // Always block sensitive types first
-    if (element.type === 'password' || element.type === 'email' || element.type === 'tel') return null;
+    if (
+      element.type === "password" ||
+      element.type === "email" ||
+      element.type === "tel"
+    )
+      return null;
 
     // Iterate patterns — sensitive must be first entry in the object to act as a gate
     for (const [type, keywords] of Object.entries(FORM_FIELD_PATTERNS)) {
-      const normalizedKeywords = keywords.map(k => k.replace(/[-\s]/g, '_'));
-      if (normalizedKeywords.some(k => combined.includes(k))) {
-        return type === 'sensitive' ? null : type;
+      const normalizedKeywords = keywords.map((k) => k.replace(/[-\s]/g, "_"));
+      if (normalizedKeywords.some((k) => combined.includes(k))) {
+        return type === "sensitive" ? null : type;
       }
     }
 
     // Special case: bare 'os' as a whole word (e.g. name="os", id="os")
-    if (/(?:^|_)os(?:_|$)/.test(combined)) return 'os';
+    if (/(?:^|_)os(?:_|$)/.test(combined)) return "os";
 
     // Special case: bare 'tz' as a whole word (e.g. name="tz", name="user_tz")
-    if (/(?:^|_)tz(?:_|$)/.test(combined)) return 'timezone';
+    if (/(?:^|_)tz(?:_|$)/.test(combined)) return "timezone";
 
     return null;
   }
 
   function detectOS() {
     const ua = navigator.userAgent;
-    if (/Windows NT 11/.test(ua)) return 'Windows 11';
-    if (/Windows NT 10/.test(ua)) return 'Windows 10';
-    if (/Mac OS X/.test(ua)) { const v = ua.match(/Mac OS X ([\d_]+)/); return v ? `macOS ${v[1].replace(/_/g,'.')}` : 'macOS'; }
-    if (/Linux/.test(ua)) return 'Linux';
-    if (/Android/.test(ua)) { const v = ua.match(/Android ([\d.]+)/); return v ? `Android ${v[1]}` : 'Android'; }
-    if (/iPhone|iPad/.test(ua)) return 'iOS';
+    if (/Windows NT 11/.test(ua)) return "Windows 11";
+    if (/Windows NT 10/.test(ua)) return "Windows 10";
+    if (/Mac OS X/.test(ua)) {
+      const v = ua.match(/Mac OS X ([\d_]+)/);
+      return v ? `macOS ${v[1].replace(/_/g, ".")}` : "macOS";
+    }
+    if (/Linux/.test(ua)) return "Linux";
+    if (/Android/.test(ua)) {
+      const v = ua.match(/Android ([\d.]+)/);
+      return v ? `Android ${v[1]}` : "Android";
+    }
+    if (/iPhone|iPad/.test(ua)) return "iOS";
     return null;
   }
 
   function detectBrowser() {
     const ua = navigator.userAgent;
-    if (/Edg\//.test(ua)) { const v = ua.match(/Edg\/([\d.]+)/); return `Edge ${v ? v[1].split('.')[0] : ''}`.trim(); }
-    if (/OPR\//.test(ua)) { const v = ua.match(/OPR\/([\d.]+)/); return `Opera ${v ? v[1].split('.')[0] : ''}`.trim(); }
-    if (/Chrome\//.test(ua)) { const v = ua.match(/Chrome\/([\d.]+)/); return `Chrome ${v ? v[1].split('.')[0] : ''}`.trim(); }
-    if (/Firefox\//.test(ua)) { const v = ua.match(/Firefox\/([\d.]+)/); return `Firefox ${v ? v[1].split('.')[0] : ''}`.trim(); }
-    if (/Safari\//.test(ua)) return 'Safari';
+    if (/Edg\//.test(ua)) {
+      const v = ua.match(/Edg\/([\d.]+)/);
+      return `Edge ${v ? v[1].split(".")[0] : ""}`.trim();
+    }
+    if (/OPR\//.test(ua)) {
+      const v = ua.match(/OPR\/([\d.]+)/);
+      return `Opera ${v ? v[1].split(".")[0] : ""}`.trim();
+    }
+    if (/Chrome\//.test(ua)) {
+      const v = ua.match(/Chrome\/([\d.]+)/);
+      return `Chrome ${v ? v[1].split(".")[0] : ""}`.trim();
+    }
+    if (/Firefox\//.test(ua)) {
+      const v = ua.match(/Firefox\/([\d.]+)/);
+      return `Firefox ${v ? v[1].split(".")[0] : ""}`.trim();
+    }
+    if (/Safari\//.test(ua)) return "Safari";
     return null;
   }
 
@@ -104,58 +208,94 @@
     const nearbyLabel = getNearbyLabel(element);
     const meta = {
       fieldType,
-      fieldLabel: nearbyLabel || element.placeholder || element.name || element.id || fieldType,
+      fieldLabel:
+        nearbyLabel ||
+        element.placeholder ||
+        element.name ||
+        element.id ||
+        fieldType,
       isFormFill: false,
-      candidates: []
+      candidates: [],
     };
 
     // ── Deterministic local candidates (device info — no tabs needed) ────────
-    if (fieldType === 'os') {
+    if (fieldType === "os") {
       const os = detectOS();
       if (os) {
-        meta.candidates.push({ value: os, source: 'Your device', confidence: 1.0 });
+        meta.candidates.push({
+          value: os,
+          source: "Your device",
+          confidence: 1.0,
+        });
         meta.isFormFill = true;
       }
     }
 
-    if (fieldType === 'browser') {
+    if (fieldType === "browser") {
       const browser = detectBrowser();
       if (browser) {
-        meta.candidates.push({ value: browser, source: 'Your device', confidence: 1.0 });
+        meta.candidates.push({
+          value: browser,
+          source: "Your device",
+          confidence: 1.0,
+        });
         meta.isFormFill = true;
       }
     }
 
-    if (fieldType === 'issue_description') {
+    if (fieldType === "issue_description") {
       const os = detectOS();
       const browser = detectBrowser();
       if (os && browser) {
-        meta.candidates.push({ value: `${os} / ${browser}`, source: 'Your device', confidence: 0.9 });
+        meta.candidates.push({
+          value: `${os} / ${browser}`,
+          source: "Your device",
+          confidence: 0.9,
+        });
         meta.isFormFill = true;
       }
     }
 
-    if (fieldType === 'version') {
+    if (fieldType === "version") {
       const browser = detectBrowser();
       if (browser) {
-        meta.candidates.push({ value: browser, source: 'Your browser version', confidence: 0.8 });
+        meta.candidates.push({
+          value: browser,
+          source: "Your browser version",
+          confidence: 0.8,
+        });
         meta.isFormFill = true;
       }
     }
-    if (fieldType === 'timezone') {
+    if (fieldType === "timezone") {
       try {
         const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
         if (tz) {
-          meta.candidates.push({ value: tz, source: 'Your device', confidence: 1.0 });
+          meta.candidates.push({
+            value: tz,
+            source: "Your device",
+            confidence: 1.0,
+          });
           meta.isFormFill = true;
         }
-      } catch (e) { /* unsupported */ }
+      } catch (e) {
+        /* unsupported */
+      }
     }
 
     // ── Tab-dependent types: mark isFormFill so service-worker uses
     //    form-fill prompt path, candidates filled in by service worker
     //    via form-detector using the open tabs it can access ───────────────────
-    const tabDependentTypes = ['job_title', 'company', 'skills', 'linkedin_url', 'github_url', 'website', 'issue_subject', 'experience_years'];
+    const tabDependentTypes = [
+      "job_title",
+      "company",
+      "skills",
+      "linkedin_url",
+      "github_url",
+      "website",
+      "issue_subject",
+      "experience_years",
+    ];
     if (tabDependentTypes.includes(fieldType)) {
       // Flag it so groq-service uses the form-field prompt, even if no local candidates
       meta.isFormFill = true;
@@ -180,9 +320,13 @@
     let parent = element.parentElement;
     for (let i = 0; i < 4; i++) {
       if (!parent) break;
-      if (parent.tagName === 'LABEL') return parent.textContent.trim().replace(element.value || '', '').trim();
+      if (parent.tagName === "LABEL")
+        return parent.textContent
+          .trim()
+          .replace(element.value || "", "")
+          .trim();
       // Sibling label
-      const siblingLabel = parent.querySelector('label');
+      const siblingLabel = parent.querySelector("label");
       if (siblingLabel) return siblingLabel.textContent.trim();
       parent = parent.parentElement;
     }
@@ -191,26 +335,32 @@
 
   // ── Overlay setup ──────────────────────────────────────────────────────────
 
-  function isBlockedDomain() {
+  function isBlockedDomain(blockedDomains) {
+    if (!Array.isArray(blockedDomains)) return false;
     const host = window.location.hostname.toLowerCase();
-    return BLOCKED_DOMAINS.some(domain => host.includes(domain));
+    return blockedDomains.some((domain) => host.includes(domain));
   }
 
-  function initialize() {
-    if (isBlockedDomain()) {
-      console.log('AI Context Assistant: disabled on', window.location.hostname);
-      return;
+  async function initialize() {
+    try {
+      const blockedDomains = (await configManager.get("blockedDomains")) || [];
+      if (isBlockedDomain(blockedDomains)) {
+        console.log("AI Context Assistant: disabled", window.location.hostname);
+        return;
+      }
+      setupInputTracking();
+      setupMessageListener();
+      createSuggestionOverlay();
+      setupAddressBarDetection();
+      console.log("AI Context Assistant - Session+FormFill mode active");
+    } catch (error) {
+      console.error("Failed to load extension config:", error);
     }
-    setupInputTracking();
-    setupMessageListener();
-    createSuggestionOverlay();
-    setupAddressBarDetection();
-    console.log('AI Context Assistant - Session+FormFill mode active');
   }
 
   function createSuggestionOverlay() {
-    suggestionOverlay = document.createElement('div');
-    suggestionOverlay.id = 'ai-context-suggestion-overlay';
+    suggestionOverlay = document.createElement("div");
+    suggestionOverlay.id = "ai-context-suggestion-overlay";
 
     suggestionOverlay.style.cssText = `
       position: fixed;
@@ -235,7 +385,7 @@
       animation: aiSlideIn 0.18s cubic-bezier(0.34, 1.26, 0.64, 1);
     `;
 
-    const style = document.createElement('style');
+    const style = document.createElement("style");
     style.textContent = `
       @keyframes aiSlideIn {
         from { opacity: 0; transform: translateY(-6px) scale(0.98); }
@@ -281,69 +431,99 @@
       const url = location.href;
       if (url !== lastUrl) {
         lastUrl = url;
-        if (url.includes('google.com/search')) setTimeout(() => attachToGoogleSearch(), 100);
+        if (url.includes("google.com/search"))
+          setTimeout(() => attachToGoogleSearch(), 100);
       }
     }).observe(document, { subtree: true, childList: true });
 
-    if (location.href.includes('google.com/search')) setTimeout(() => attachToGoogleSearch(), 500);
+    if (location.href.includes("google.com/search"))
+      setTimeout(() => attachToGoogleSearch(), 500);
   }
 
   function attachToGoogleSearch() {
-    const selectors = ['input[name="q"]', 'textarea[name="q"]', 'input[aria-label*="Search"]', '.gLFyf', 'input[type="search"]'];
+    const selectors = [
+      'input[name="q"]',
+      'textarea[name="q"]',
+      'input[aria-label*="Search"]',
+      ".gLFyf",
+      'input[type="search"]',
+    ];
     for (const selector of selectors) {
       const searchInput = document.querySelector(selector);
       if (searchInput && !searchInput.dataset.aiAssistantAttached) {
-        searchInput.dataset.aiAssistantAttached = 'true';
+        searchInput.dataset.aiAssistantAttached = "true";
         attachInputListeners(searchInput);
-        searchInput.addEventListener('focus', () => { currentInput = searchInput; isAddressBar = true; });
+        searchInput.addEventListener("focus", () => {
+          currentInput = searchInput;
+          isAddressBar = true;
+        });
         break;
       }
     }
   }
 
   function setupInputTracking() {
-    document.addEventListener('focusin', (e) => {
-      const target = e.target;
-      if (isInputElement(target)) {
-        currentInput = target;
-        lastInputValue = getInputValue(target);
-        isAddressBar = isGoogleSearchInput(target);
+    document.addEventListener(
+      "focusin",
+      (e) => {
+        const target = e.target;
+        if (isInputElement(target)) {
+          currentInput = target;
+          lastInputValue = getInputValue(target);
+          isAddressBar = isGoogleSearchInput(target);
 
-        if (isSensitiveField(target)) {
-          currentInput = null;
-          hideSuggestion();
-          return;
+          if (isSensitiveField(target)) {
+            currentInput = null;
+            hideSuggestion();
+            return;
+          }
+          attachInputListeners(target);
         }
-        attachInputListeners(target);
-      }
-    }, true);
+      },
+      true,
+    );
 
-    document.addEventListener('focusout', (e) => {
-      if (currentInput === e.target) {
-        setTimeout(() => {
-          hideSuggestion();
-          currentInput = null;
-          currentSuggestions = [];
-          isAddressBar = false;
-        }, 200);
-      }
-    }, true);
+    document.addEventListener(
+      "focusout",
+      (e) => {
+        if (currentInput === e.target) {
+          setTimeout(() => {
+            hideSuggestion();
+            currentInput = null;
+            currentSuggestions = [];
+            isAddressBar = false;
+          }, 200);
+        }
+      },
+      true,
+    );
 
-    if (window.location.href.includes('claude.ai')) setupClaudeInputDetection();
+    if (window.location.href.includes("claude.ai")) setupClaudeInputDetection();
   }
 
   function setupClaudeInputDetection() {
-    const selectors = ['.ProseMirror', 'div[contenteditable="true"]', 'div[role="textbox"]'];
+    const selectors = [
+      ".ProseMirror",
+      'div[contenteditable="true"]',
+      'div[role="textbox"]',
+    ];
     for (const selector of selectors) {
       const input = document.querySelector(selector);
-      if (input && input.offsetHeight > 0) { attachInputListeners(input); return; }
+      if (input && input.offsetHeight > 0) {
+        attachInputListeners(input);
+        return;
+      }
     }
     let attempts = 0;
     const observer = new MutationObserver(() => {
       attempts++;
       for (const selector of selectors) {
         const input = document.querySelector(selector);
-        if (input && input.offsetHeight > 0) { attachInputListeners(input); observer.disconnect(); return; }
+        if (input && input.offsetHeight > 0) {
+          attachInputListeners(input);
+          observer.disconnect();
+          return;
+        }
       }
       if (attempts >= 20) observer.disconnect();
     });
@@ -351,7 +531,15 @@
     setTimeout(() => {
       for (const selector of selectors) {
         const input = document.querySelector(selector);
-        if (input && input.offsetHeight > 0 && !input.dataset.listenersAttached) { attachInputListeners(input); observer.disconnect(); return; }
+        if (
+          input &&
+          input.offsetHeight > 0 &&
+          !input.dataset.listenersAttached
+        ) {
+          attachInputListeners(input);
+          observer.disconnect();
+          return;
+        }
       }
     }, 1500);
   }
@@ -359,24 +547,28 @@
   function isGoogleSearchInput(element) {
     if (!element) return false;
     const url = window.location.href.toLowerCase();
-    if (!url.includes('google.com')) return false;
-    return element.name?.toLowerCase() === 'q' ||
-           element.getAttribute('aria-label')?.toLowerCase().includes('search') ||
-           element.classList.contains('gLFyf');
+    if (!url.includes("google.com")) return false;
+    return (
+      element.name?.toLowerCase() === "q" ||
+      element.getAttribute("aria-label")?.toLowerCase().includes("search") ||
+      element.classList.contains("gLFyf")
+    );
   }
 
   function getInputValue(input) {
-    return input.contentEditable === 'true' ? (input.textContent || '') : (input.value || '');
+    return input.contentEditable === "true"
+      ? input.textContent || ""
+      : input.value || "";
   }
 
   function setInputValue(input, value) {
-    if (input.contentEditable === 'true') input.textContent = value;
+    if (input.contentEditable === "true") input.textContent = value;
     else input.value = value;
   }
 
   function attachInputListeners(input) {
     if (input.dataset.listenersAttached) return;
-    input.dataset.listenersAttached = 'true';
+    input.dataset.listenersAttached = "true";
 
     const inputHandler = () => {
       if (currentInput !== input) return;
@@ -392,15 +584,34 @@
 
     const keydownHandler = (e) => {
       if (currentInput !== input) return;
-      if (e.key === 'Tab' && currentSuggestions.length > 0) { e.preventDefault(); acceptSuggestion(); return; }
-      if (e.key === 'ArrowDown' && currentSuggestions.length > 1) { e.preventDefault(); activeSuggestionIndex = (activeSuggestionIndex + 1) % currentSuggestions.length; updateSuggestionDisplay(); }
-      if (e.key === 'ArrowUp' && currentSuggestions.length > 1) { e.preventDefault(); activeSuggestionIndex = (activeSuggestionIndex - 1 + currentSuggestions.length) % currentSuggestions.length; updateSuggestionDisplay(); }
-      if (e.key === 'Escape') { hideSuggestion(); currentSuggestions = []; }
+      if (e.key === "Tab" && currentSuggestions.length > 0) {
+        e.preventDefault();
+        acceptSuggestion();
+        return;
+      }
+      if (e.key === "ArrowDown" && currentSuggestions.length > 1) {
+        e.preventDefault();
+        activeSuggestionIndex =
+          (activeSuggestionIndex + 1) % currentSuggestions.length;
+        updateSuggestionDisplay();
+      }
+      if (e.key === "ArrowUp" && currentSuggestions.length > 1) {
+        e.preventDefault();
+        activeSuggestionIndex =
+          (activeSuggestionIndex - 1 + currentSuggestions.length) %
+          currentSuggestions.length;
+        updateSuggestionDisplay();
+      }
+      if (e.key === "Escape") {
+        hideSuggestion();
+        currentSuggestions = [];
+      }
     };
 
-    input.addEventListener('input', inputHandler);
-    input.addEventListener('keydown', keydownHandler);
-    if (input.contentEditable === 'true') input.addEventListener('DOMCharacterDataModified', inputHandler);
+    input.addEventListener("input", inputHandler);
+    input.addEventListener("keydown", keydownHandler);
+    if (input.contentEditable === "true")
+      input.addEventListener("DOMCharacterDataModified", inputHandler);
   }
 
   function debouncedGenerateSuggestions(input, value) {
@@ -421,33 +632,45 @@
         current_page: {
           title: document.title,
           url: window.location.href,
-          headings: Array.from(document.querySelectorAll('h1, h2, h3'))
-            .slice(0, 5).map(h => h.textContent.trim()).filter(Boolean)
+          headings: Array.from(document.querySelectorAll("h1, h2, h3"))
+            .slice(0, 5)
+            .map((h) => h.textContent.trim())
+            .filter(Boolean),
         },
         is_address_bar: isAddressBar,
-        is_ai_chat: window.location.href.includes('claude.ai') || window.location.href.includes('chat.openai.com')
+        is_ai_chat:
+          window.location.href.includes("claude.ai") ||
+          window.location.href.includes("chat.openai.com"),
       };
 
       const response = await chrome.runtime.sendMessage({
-        action: 'generateSuggestions',
+        action: "generateSuggestions",
         data: {
           context: pageContext,
-          fieldName: input.name || input.id || input.placeholder || '',
+          fieldName: input.name || input.id || input.placeholder || "",
           // ── New: send form metadata to service worker ──────────────────
-          fieldMeta
-        }
+          fieldMeta,
+        },
       });
 
       // Stale check
       const currentValue = getInputValue(input);
-      if (currentValue !== value) { console.log('Stale result discarded'); return; }
+      if (currentValue !== value) {
+        console.log("Stale result discarded");
+        return;
+      }
 
       if (response && response.success) {
         const suggestions = response.suggestions || [];
         if (suggestions.length > 0) {
           currentSuggestions = suggestions;
           activeSuggestionIndex = 0;
-          showSuggestion(input, currentSuggestions[0], response.reason, response.isFormFill);
+          showSuggestion(
+            input,
+            currentSuggestions[0],
+            response.reason,
+            response.isFormFill,
+          );
         } else {
           hideSuggestion();
           currentSuggestions = [];
@@ -457,7 +680,7 @@
         currentSuggestions = [];
       }
     } catch (error) {
-      console.error('Failed to generate suggestions:', error);
+      console.error("Failed to generate suggestions:", error);
       hideSuggestion();
       currentSuggestions = [];
     }
@@ -466,21 +689,26 @@
   function acceptSuggestion() {
     if (!currentInput || currentSuggestions.length === 0) return;
     const suggestion = currentSuggestions[activeSuggestionIndex];
-    const suggestionText = typeof suggestion === 'string' ? suggestion : suggestion.text;
+    const suggestionText =
+      typeof suggestion === "string" ? suggestion : suggestion.text;
     if (!suggestionText) return;
 
     setInputValue(currentInput, suggestionText);
-    currentInput.dispatchEvent(new Event('input', { bubbles: true }));
-    currentInput.dispatchEvent(new Event('change', { bubbles: true }));
-    if (currentInput.contentEditable === 'true') currentInput.dispatchEvent(new Event('textInput', { bubbles: true }));
+    currentInput.dispatchEvent(new Event("input", { bubbles: true }));
+    currentInput.dispatchEvent(new Event("change", { bubbles: true }));
+    if (currentInput.contentEditable === "true")
+      currentInput.dispatchEvent(new Event("textInput", { bubbles: true }));
 
     lastInputValue = suggestionText;
     hideSuggestion();
     currentSuggestions = [];
 
     if (currentInput.setSelectionRange) {
-      currentInput.setSelectionRange(suggestionText.length, suggestionText.length);
-    } else if (currentInput.contentEditable === 'true') {
+      currentInput.setSelectionRange(
+        suggestionText.length,
+        suggestionText.length,
+      );
+    } else if (currentInput.contentEditable === "true") {
       const range = document.createRange();
       const selection = window.getSelection();
       range.selectNodeContents(currentInput);
@@ -492,9 +720,16 @@
 
   // ── Display ────────────────────────────────────────────────────────────────
 
-  function showSuggestion(input, suggestionData, reason = '', isFormFill = false) {
-    const text = typeof suggestionData === 'string' ? suggestionData : suggestionData.text;
-    const derivation = typeof suggestionData === 'object' ? suggestionData.derivation : null;
+  function showSuggestion(
+    input,
+    suggestionData,
+    reason = "",
+    isFormFill = false,
+  ) {
+    const text =
+      typeof suggestionData === "string" ? suggestionData : suggestionData.text;
+    const derivation =
+      typeof suggestionData === "object" ? suggestionData.derivation : null;
 
     if (!suggestionOverlay) return;
 
@@ -503,46 +738,53 @@
     const left = rect.left + window.scrollX;
     if (isAddressBar) top = rect.bottom + window.scrollY + 14;
 
-    suggestionOverlay.style.display = 'block';
+    suggestionOverlay.style.display = "block";
     suggestionOverlay.style.left = `${left}px`;
     suggestionOverlay.style.top = `${top}px`;
     suggestionOverlay.style.width = `${Math.max(rect.width, 320)}px`;
 
     // Counter pill
-    const counter = currentSuggestions.length > 1
-      ? `<span style="display:inline-flex;align-items:center;gap:3px;background:rgba(255,255,255,0.12);border-radius:20px;padding:1px 7px;font-size:10px;font-weight:500;letter-spacing:0.02em;">↑↓ ${activeSuggestionIndex + 1}/${currentSuggestions.length}</span>`
-      : '';
+    const counter =
+      currentSuggestions.length > 1
+        ? `<span style="display:inline-flex;align-items:center;gap:3px;background:rgba(255,255,255,0.12);border-radius:20px;padding:1px 7px;font-size:10px;font-weight:500;letter-spacing:0.02em;">↑↓ ${activeSuggestionIndex + 1}/${currentSuggestions.length}</span>`
+        : "";
 
     // ── Badge: form-fill (amber) vs session-aware (blue) vs default ──────────
-    let badge = '';
+    let badge = "";
     if (isFormFill) {
       badge = `<span class="ai-form-fill-badge">⚡ Smart Fill</span>`;
     } else {
       // Check if derivation references session thread
-      const isSessionBased = derivation?.toLowerCase().includes('session') ||
-                             derivation?.toLowerCase().includes('thread') ||
-                             derivation?.toLowerCase().startsWith('session:');
+      const isSessionBased =
+        derivation?.toLowerCase().includes("session") ||
+        derivation?.toLowerCase().includes("thread") ||
+        derivation?.toLowerCase().startsWith("session:");
       if (isSessionBased) {
         badge = `<span class="ai-session-badge">🧠 Session</span>`;
       } else if (isAddressBar) {
         badge = `<span style="background:rgba(255,255,255,0.10);border:1px solid rgba(255,255,255,0.14);border-radius:20px;padding:1px 7px;font-size:10px;font-weight:500;letter-spacing:0.03em;color:rgba(255,255,255,0.7);">🔍 Search</span>`;
-      } else if (window.location.href.includes('claude.ai') || window.location.href.includes('chat.openai.com')) {
+      } else if (
+        window.location.href.includes("claude.ai") ||
+        window.location.href.includes("chat.openai.com")
+      ) {
         badge = `<span style="background:rgba(255,255,255,0.10);border:1px solid rgba(255,255,255,0.14);border-radius:20px;padding:1px 7px;font-size:10px;font-weight:500;letter-spacing:0.03em;color:rgba(255,255,255,0.7);">🤖 AI Chat</span>`;
       }
     }
 
-    const topRow = (badge || counter)
-      ? `<div style="display:flex;align-items:center;gap:6px;margin-bottom:7px;">${badge}${counter}</div>`
-      : '';
+    const topRow =
+      badge || counter
+        ? `<div style="display:flex;align-items:center;gap:6px;margin-bottom:7px;">${badge}${counter}</div>`
+        : "";
 
-    const caption = (derivation || reason)
-      ? `<div style="margin-top:8px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.10);font-size:11px;color:rgba(255,255,255,0.52);line-height:1.45;font-weight:400;">${escapeHtml(derivation || reason)}</div>`
-      : '';
+    const caption =
+      derivation || reason
+        ? `<div style="margin-top:8px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.10);font-size:11px;color:rgba(255,255,255,0.52);line-height:1.45;font-weight:400;">${escapeHtml(derivation || reason)}</div>`
+        : "";
 
     suggestionOverlay.innerHTML = `
       ${topRow}
       <div style="font-weight:500;font-size:13.5px;line-height:1.4;color:rgba(255,255,255,0.97);margin-bottom:3px;">${escapeHtml(text)}</div>
-      <div style="font-size:10.5px;color:rgba(255,255,255,0.38);font-weight:400;">Tab to accept${currentSuggestions.length > 1 ? ' · ↑↓ to cycle' : ''}</div>
+      <div style="font-size:10.5px;color:rgba(255,255,255,0.38);font-weight:400;">Tab to accept${currentSuggestions.length > 1 ? " · ↑↓ to cycle" : ""}</div>
       ${caption}
     `;
   }
@@ -554,7 +796,7 @@
     const left = rect.left + window.scrollX;
     if (isAddressBar) top = rect.bottom + window.scrollY + 14;
 
-    suggestionOverlay.style.display = 'block';
+    suggestionOverlay.style.display = "block";
     suggestionOverlay.style.left = `${left}px`;
     suggestionOverlay.style.top = `${top}px`;
     suggestionOverlay.innerHTML = `
@@ -575,102 +817,185 @@
   }
 
   function hideSuggestion() {
-    if (suggestionOverlay) suggestionOverlay.style.display = 'none';
+    if (suggestionOverlay) suggestionOverlay.style.display = "none";
   }
 
   function escapeHtml(text) {
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     div.textContent = text;
     return div.innerHTML;
   }
 
   function detectPageType() {
     const url = window.location.href.toLowerCase();
-    if (url.includes('chat.openai.com') || url.includes('claude.ai') || url.includes('gemini.google.com') || url.includes('copilot.microsoft.com')) return 'ai_chat';
-    if (url.includes('github.com') || url.includes('stackoverflow.com')) return 'coding';
-    if (url.includes('google.com/search') || url.includes('bing.com/search')) return 'search';
-    if (url.includes('docs.') || document.title.toLowerCase().includes('documentation')) return 'documentation';
-    return 'general';
+    if (
+      url.includes("chat.openai.com") ||
+      url.includes("claude.ai") ||
+      url.includes("gemini.google.com") ||
+      url.includes("copilot.microsoft.com")
+    )
+      return "ai_chat";
+    if (url.includes("github.com") || url.includes("stackoverflow.com"))
+      return "coding";
+    if (url.includes("google.com/search") || url.includes("bing.com/search"))
+      return "search";
+    if (
+      url.includes("docs.") ||
+      document.title.toLowerCase().includes("documentation")
+    )
+      return "documentation";
+    return "general";
   }
 
   function isInputElement(element) {
     if (!element) return false;
     const tagName = element.tagName?.toLowerCase();
     const type = element.type?.toLowerCase();
-    if (tagName === 'textarea') return true;
-    if (tagName === 'input' && (type === 'text' || type === 'search' || type === 'url' || !type)) return true;
-    if (element.contentEditable === 'true') return true;
-    if (element.getAttribute('role') === 'textbox') return true;
+    if (tagName === "textarea") return true;
+    if (
+      tagName === "input" &&
+      (type === "text" || type === "search" || type === "url" || !type)
+    )
+      return true;
+    if (element.contentEditable === "true") return true;
+    if (element.getAttribute("role") === "textbox") return true;
     return false;
   }
 
   function isSensitiveField(element) {
     if (!element) return false;
     const type = element.type?.toLowerCase();
-    if (type === 'password' || type === 'tel' || type === 'number' || type === 'email') return true;
-    const combinedText = `${element.name} ${element.id} ${element.autocomplete} ${element.placeholder}`.toLowerCase();
-    return ['password', 'passwd', 'credit', 'card', 'cvv', 'ssn', 'bank', 'pin', 'token', 'auth', 'login', 'otp', 'verification'].some(k => combinedText.includes(k));
+    if (
+      type === "password" ||
+      type === "tel" ||
+      type === "number" ||
+      type === "email"
+    )
+      return true;
+    const combinedText =
+      `${element.name} ${element.id} ${element.autocomplete} ${element.placeholder}`.toLowerCase();
+    return [
+      "password",
+      "passwd",
+      "credit",
+      "card",
+      "cvv",
+      "ssn",
+      "bank",
+      "pin",
+      "token",
+      "auth",
+      "login",
+      "otp",
+      "verification",
+    ].some((k) => combinedText.includes(k));
   }
 
   function setupMessageListener() {
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-      handleMessage(request).then(sendResponse).catch(error => sendResponse({ error: error.message }));
+      handleMessage(request)
+        .then(sendResponse)
+        .catch((error) => sendResponse({ error: error.message }));
       return true;
     });
   }
 
   async function handleMessage(request) {
     switch (request.action) {
-      case 'getPageContext': return getPageContext();
-      case 'getActiveInput': return getActiveInput();
-      case 'insertSuggestion': return insertSuggestion(request.data.text);
-      case 'toggleExtension':
+      case "getPageContext":
+        return getPageContext();
+      case "getActiveInput":
+        return getActiveInput();
+      case "insertSuggestion":
+        return insertSuggestion(request.data.text);
+      case "toggleExtension":
         if (!request.data.enabled) hideSuggestion();
         return { success: true };
-      default: throw new Error(`Unknown action: ${request.action}`);
+      default:
+        throw new Error(`Unknown action: ${request.action}`);
     }
   }
 
   function getPageContext() {
-    const context = { title: document.title, headings: [], summary: '', mainContent: '', chatHistory: [] };
+    const context = {
+      title: document.title,
+      headings: [],
+      summary: "",
+      mainContent: "",
+      chatHistory: [],
+    };
     try {
-      context.headings = Array.from(document.querySelectorAll('h1, h2, h3')).slice(0, 10).map(h => h.textContent.trim()).filter(Boolean);
+      context.headings = Array.from(document.querySelectorAll("h1, h2, h3"))
+        .slice(0, 10)
+        .map((h) => h.textContent.trim())
+        .filter(Boolean);
       const metaDesc = document.querySelector('meta[name="description"]');
-      context.summary = metaDesc ? metaDesc.content : '';
+      context.summary = metaDesc ? metaDesc.content : "";
 
       const url = window.location.href.toLowerCase();
-      if (url.includes('chat.openai.com')) {
-        const messages = Array.from(document.querySelectorAll('[data-message-author-role]')).slice(-5).map(m => m.textContent.trim()).filter(Boolean);
-        if (messages.length) { context.mainContent = messages.join('\n---\n'); context.chatHistory = messages; }
-      } else if (url.includes('claude.ai')) {
-        let messages = Array.from(document.querySelectorAll('[data-test-render-count]')).slice(-5).map(m => m.textContent.trim()).filter(Boolean);
-        if (!messages.length) messages = Array.from(document.querySelectorAll('.font-user-message, .font-claude-message')).slice(-5).map(m => m.textContent.trim()).filter(Boolean);
-        if (messages.length) { context.mainContent = messages.join('\n---\n'); context.chatHistory = messages; }
+      if (url.includes("chat.openai.com")) {
+        const messages = Array.from(
+          document.querySelectorAll("[data-message-author-role]"),
+        )
+          .slice(-5)
+          .map((m) => m.textContent.trim())
+          .filter(Boolean);
+        if (messages.length) {
+          context.mainContent = messages.join("\n---\n");
+          context.chatHistory = messages;
+        }
+      } else if (url.includes("claude.ai")) {
+        let messages = Array.from(
+          document.querySelectorAll("[data-test-render-count]"),
+        )
+          .slice(-5)
+          .map((m) => m.textContent.trim())
+          .filter(Boolean);
+        if (!messages.length)
+          messages = Array.from(
+            document.querySelectorAll(
+              ".font-user-message, .font-claude-message",
+            ),
+          )
+            .slice(-5)
+            .map((m) => m.textContent.trim())
+            .filter(Boolean);
+        if (messages.length) {
+          context.mainContent = messages.join("\n---\n");
+          context.chatHistory = messages;
+        }
       } else {
-        const mainEl = document.querySelector('main, article, .content, #content');
-        if (mainEl) context.mainContent = mainEl.textContent.trim().substring(0, 1000);
+        const mainEl = document.querySelector(
+          "main, article, .content, #content",
+        );
+        if (mainEl)
+          context.mainContent = mainEl.textContent.trim().substring(0, 1000);
       }
-    } catch (error) { console.error('Error in getPageContext:', error); }
+    } catch (error) {
+      console.error("Error in getPageContext:", error);
+    }
     return context;
   }
 
   function getActiveInput() {
-    if (!currentInput || isSensitiveField(currentInput)) return { text: '' };
+    if (!currentInput || isSensitiveField(currentInput)) return { text: "" };
     return { text: getInputValue(currentInput).trim() };
   }
 
   function insertSuggestion(text) {
-    if (!currentInput || isSensitiveField(currentInput)) return { success: false, error: 'No active input field' };
+    if (!currentInput || isSensitiveField(currentInput))
+      return { success: false, error: "No active input field" };
     try {
       setInputValue(currentInput, text);
-      currentInput.dispatchEvent(new Event('input', { bubbles: true }));
-      currentInput.dispatchEvent(new Event('change', { bubbles: true }));
+      currentInput.dispatchEvent(new Event("input", { bubbles: true }));
+      currentInput.dispatchEvent(new Event("change", { bubbles: true }));
       return { success: true };
     } catch (error) {
       return { success: false, error: error.message };
     }
   }
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initialize);
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", initialize);
   else initialize();
 })();

--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -21,8 +21,9 @@ const configManager = {
     return defaultValue;
   },
   async getBlockedDomains() {
-    const blockedDomains = await this.get("blockedDomains", []);
-    return Array.isArray(blockedDomains) ? blockedDomains : [];
+    const result = await chrome.storage.local.get('config');
+    const blockedDomains = result?.config?.blockedDomains;
+    return Array.isArray(blockedDomains) ? blockedDomains : ['linkedin.com'];
   },
 };
 
@@ -369,7 +370,8 @@ const configManager = {
 
   async function initialize() {
     try {
-      const blockedDomains = (await configManager.get("blockedDomains")) || [];
+      const blockedDomains = await configManager.getBlockedDomains();
+      console.log('BLOCKED DOMAINS:', blockedDomains);
       if (isBlockedDomain(blockedDomains)) {
         console.log("AI Context Assistant: disabled", window.location.hostname);
         return;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -712,5 +712,6 @@ body.dark .connection-status.error {
 }
 
 .tag button:focus {
-    outline: none;
+    outline: 2px solid white;
+    outline-offset: 2px;
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,634 +1,716 @@
 /* Popup Styles - CSS Variables */
 :root {
-  --primary: #4A90E2;
-  --primary-dark: #357ABD;
-  --secondary: #6C757D;
-  --success: #4CAF50;
-  --danger: #E74C3C;
-  --warning: #FFC107;
-  --bg: #FFFFFF;
-  --bg-secondary: #F8F9FA;
-  --border: #E0E0E0;
-  --text: #212529;
-  --text-secondary: #6C757D;
-  --shadow: rgba(0, 0, 0, 0.1);
+    --primary: #4a90e2;
+    --primary-dark: #357abd;
+    --secondary: #6c757d;
+    --success: #4caf50;
+    --danger: #e74c3c;
+    --warning: #ffc107;
+    --bg: #ffffff;
+    --bg-secondary: #f8f9fa;
+    --border: #e0e0e0;
+    --text: #212529;
+    --text-secondary: #6c757d;
+    --shadow: rgba(0, 0, 0, 0.1);
 }
 
 body.dark {
-  --primary: #4A90E2;
-  --primary-dark: #357ABD;
-  --secondary: #6C757D;
-  --success: #4CAF50;
-  --danger: #E74C3C;
-  --warning: #FFC107;
-  --bg: #1a1b1e;
-  --bg-secondary: #25262b;
-  --border: #2e2f34;
-  --text: #e4e5e9;
-  --text-secondary: #909296;
-  --shadow: rgba(0, 0, 0, 0.4);
+    --primary: #4a90e2;
+    --primary-dark: #357abd;
+    --secondary: #6c757d;
+    --success: #4caf50;
+    --danger: #e74c3c;
+    --warning: #ffc107;
+    --bg: #1a1b1e;
+    --bg-secondary: #25262b;
+    --border: #2e2f34;
+    --text: #e4e5e9;
+    --text-secondary: #909296;
+    --shadow: rgba(0, 0, 0, 0.4);
 }
 
 /* Reset & Base Styles */
 * {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--text);
-  background: var(--bg);
-  width: 400px;
-  min-height: 500px;
-  max-height: 600px;
-  overflow: hidden;
+    font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+        Cantarell, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text);
+    background: var(--bg);
+    width: 400px;
+    min-height: 500px;
+    max-height: 600px;
+    overflow: hidden;
 }
 
 .container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  max-height: 600px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-height: 600px;
 }
 
 /* Header */
 .header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
 }
 
 .logo {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--primary);
 }
 
 .logo svg {
-  flex-shrink: 0;
+    flex-shrink: 0;
 }
 
 .logo h1 {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
 }
 
 /* Views */
 .view {
-  flex: 1;
-  overflow-y: auto;
-  display: none;
+    flex: 1;
+    overflow-y: auto;
+    display: none;
 }
 
 .view:not(.hidden) {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Status Bar */
 .status-bar {
-  padding: 8px 16px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
-  color: var(--text-secondary);
+    padding: 8px 16px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-secondary);
 }
 
 .status-bar.success {
-  background: rgba(76, 175, 80, 0.1);
-  color: var(--success);
+    background: rgba(76, 175, 80, 0.1);
+    color: var(--success);
 }
 
 body.dark .status-bar.success {
-  background: rgba(76, 175, 80, 0.15);
+    background: rgba(76, 175, 80, 0.15);
 }
 
 .status-bar.error {
-  background: rgba(231, 76, 60, 0.1);
-  color: var(--danger);
+    background: rgba(231, 76, 60, 0.1);
+    color: var(--danger);
 }
 
 body.dark .status-bar.error {
-  background: rgba(231, 76, 60, 0.15);
+    background: rgba(231, 76, 60, 0.15);
 }
 
 /* Empty State */
 .empty-state {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 32px 24px;
-  text-align: center;
-  color: var(--text-secondary);
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 32px 24px;
+    text-align: center;
+    color: var(--text-secondary);
 }
 
 .empty-state svg {
-  margin-bottom: 16px;
-  opacity: 0.5;
+    margin-bottom: 16px;
+    opacity: 0.5;
 }
 
 .empty-state h2 {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text);
-  margin-bottom: 8px;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 8px;
 }
 
 .empty-state p {
-  font-size: 14px;
-  margin-bottom: 16px;
-  max-width: 300px;
+    font-size: 14px;
+    margin-bottom: 16px;
+    max-width: 300px;
 }
 
 /* Loading State */
 .loading-state {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
 }
 
 .spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid var(--border);
-  border-top-color: var(--primary);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  margin-bottom: 16px;
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--border);
+    border-top-color: var(--primary);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin-bottom: 16px;
 }
 
 @keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* Suggestions */
 .suggestions-container {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px;
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
 }
 
 .suggestions-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .suggestion-card {
-  padding: 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.2s;
+    padding: 12px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
 }
 
 .suggestion-card:hover {
-  background: var(--bg);
-  border-color: var(--primary);
-  box-shadow: 0 2px 8px var(--shadow);
+    background: var(--bg);
+    border-color: var(--primary);
+    box-shadow: 0 2px 8px var(--shadow);
 }
 
 body.dark .suggestion-card:hover {
-  background: #2c2d32;
+    background: #2c2d32;
 }
 
 .suggestion-card:active {
-  transform: scale(0.98);
+    transform: scale(0.98);
 }
 
 .suggestion-text {
-  font-size: 14px;
-  color: var(--text);
-  line-height: 1.6;
+    font-size: 14px;
+    color: var(--text);
+    line-height: 1.6;
 }
 
 .suggestion-derivation {
-  font-size: 12px;
-  color: var(--text-secondary);
-  margin-top: 8px;
-  padding: 8px;
-  background: rgba(74, 144, 226, 0.1);
-  border-left: 3px solid var(--primary);
-  border-radius: 4px;
-  line-height: 1.5;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 8px;
+    padding: 8px;
+    background: rgba(74, 144, 226, 0.1);
+    border-left: 3px solid var(--primary);
+    border-radius: 4px;
+    line-height: 1.5;
 }
 
 body.dark .suggestion-derivation {
-  background: rgba(74, 144, 226, 0.12);
+    background: rgba(74, 144, 226, 0.12);
 }
 
 .suggestion-derivation strong {
-  color: var(--primary);
-  font-weight: 600;
+    color: var(--primary);
+    font-weight: 600;
 }
 
 .suggestion-reason {
-  font-size: 12px;
-  color: var(--text-secondary);
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
 }
 
 /* Actions */
 .actions {
-  padding: 16px;
-  border-top: 1px solid var(--border);
-  background: var(--bg);
+    padding: 16px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
 }
 
 /* Buttons */
 .btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 10px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s;
-  width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
+    width: 100%;
 }
 
 .btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px var(--shadow);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px var(--shadow);
 }
 
 .btn:active {
-  transform: translateY(0);
+    transform: translateY(0);
 }
 
 .btn-primary {
-  background: var(--primary);
-  color: white;
+    background: var(--primary);
+    color: white;
 }
 
 .btn-primary:hover {
-  background: var(--primary-dark);
+    background: var(--primary-dark);
 }
 
 .btn-secondary {
-  background: var(--bg-secondary);
-  color: var(--text);
-  border: 1px solid var(--border);
+    background: var(--bg-secondary);
+    color: var(--text);
+    border: 1px solid var(--border);
 }
 
 .btn-secondary:hover {
-  background: var(--bg);
+    background: var(--bg);
 }
 
 body.dark .btn-secondary:hover {
-  background: #2c2d32;
+    background: #2c2d32;
 }
 
 .btn-danger {
-  background: var(--danger);
-  color: white;
+    background: var(--danger);
+    color: white;
 }
 
 .btn-danger:hover {
-  background: #C0392B;
+    background: #c0392b;
 }
 
 .icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
 }
 
 .icon-btn:hover {
-  background: var(--bg-secondary);
-  color: var(--text);
+    background: var(--bg-secondary);
+    color: var(--text);
 }
 
 /* Settings */
 .settings-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 16px;
-  border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px;
+    border-bottom: 1px solid var(--border);
 }
 
 .settings-header h2 {
-  font-size: 18px;
-  font-weight: 600;
+    font-size: 18px;
+    font-weight: 600;
 }
 
 .settings-content {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px;
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
 }
 
 .settings-section {
-  margin-bottom: 24px;
+    margin-bottom: 24px;
 }
 
 .settings-section h3 {
-  font-size: 14px;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: var(--text-secondary);
-  margin-bottom: 12px;
-  letter-spacing: 0.5px;
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+    letter-spacing: 0.5px;
 }
 
 .form-group {
-  margin-bottom: 16px;
+    margin-bottom: 16px;
 }
 
 .form-group label {
-  display: block;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text);
-  margin-bottom: 6px;
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+    margin-bottom: 6px;
 }
 
 .form-group input[type="text"],
 .form-group input[type="password"],
 .form-group select {
-  width: 100%;
-  padding: 8px 12px;
-  font-size: 14px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-secondary);
-  color: var(--text);
-  transition: border-color 0.2s;
+    width: 100%;
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    color: var(--text);
+    transition: border-color 0.2s;
 }
 
 .form-group input:focus,
 .form-group select:focus {
-  outline: none;
-  border-color: var(--primary);
+    outline: none;
+    border-color: var(--primary);
 }
 
 .form-group select option {
-  background: var(--bg-secondary);
-  color: var(--text);
+    background: var(--bg-secondary);
+    color: var(--text);
 }
 
 .form-group small {
-  display: block;
-  font-size: 12px;
-  color: var(--text-secondary);
-  margin-top: 4px;
+    display: block;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 4px;
 }
 
 .input-with-btn {
-  display: flex;
-  gap: 8px;
+    display: flex;
+    gap: 8px;
 }
 
 .input-with-btn input {
-  flex: 1;
+    flex: 1;
 }
 
 .checkbox-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-weight: 500;
 }
 
 .checkbox-label input[type="checkbox"] {
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
-  accent-color: var(--primary);
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+    accent-color: var(--primary);
 }
 
 .connection-status {
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  margin-top: 12px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+    margin-top: 12px;
 }
 
 .connection-status.success {
-  background: rgba(76, 175, 80, 0.1);
-  color: var(--success);
+    background: rgba(76, 175, 80, 0.1);
+    color: var(--success);
 }
 
 body.dark .connection-status.success {
-  background: rgba(76, 175, 80, 0.15);
+    background: rgba(76, 175, 80, 0.15);
 }
 
 .connection-status.error {
-  background: rgba(231, 76, 60, 0.1);
-  color: var(--danger);
+    background: rgba(231, 76, 60, 0.1);
+    color: var(--danger);
 }
 
 body.dark .connection-status.error {
-  background: rgba(231, 76, 60, 0.15);
+    background: rgba(231, 76, 60, 0.15);
 }
 
 .about-text {
-  font-size: 13px;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin-bottom: 12px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 12px;
 }
 
 .links {
-  display: flex;
-  gap: 16px;
+    display: flex;
+    gap: 16px;
 }
 
 .links a {
-  font-size: 13px;
-  color: var(--primary);
-  text-decoration: none;
+    font-size: 13px;
+    color: var(--primary);
+    text-decoration: none;
 }
 
 .links a:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 .settings-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
 }
 
 /* Toggle Switch */
 .toggle-container {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .toggle-switch {
-  position: relative;
-  display: inline-block;
-  width: 44px;
-  height: 24px;
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
 }
 
 .toggle-switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
+    opacity: 0;
+    width: 0;
+    height: 0;
 }
 
 .toggle-slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--secondary);
-  transition: 0.3s;
-  border-radius: 24px;
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--secondary);
+    transition: 0.3s;
+    border-radius: 24px;
 }
 
 .toggle-slider:before {
-  position: absolute;
-  content: "";
-  height: 18px;
-  width: 18px;
-  left: 3px;
-  bottom: 3px;
-  background-color: white;
-  transition: 0.3s;
-  border-radius: 50%;
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.3s;
+    border-radius: 50%;
 }
 
 .toggle-switch input:checked + .toggle-slider {
-  background-color: var(--success);
+    background-color: var(--success);
 }
 
 .toggle-switch input:checked + .toggle-slider:before {
-  transform: translateX(20px);
+    transform: translateX(20px);
 }
 
 .toggle-status {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  min-width: 28px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    min-width: 28px;
 }
 
 /* Dark Mode Toggle */
 #outerbox {
-  height: 24px;
-  width: 44px;
-  background-color: rgb(190, 201, 234);
-  border-radius: 30px;
-  display: flex;
-  align-items: center;
-  transition-property: all;
+    height: 24px;
+    width: 44px;
+    background-color: rgb(190, 201, 234);
+    border-radius: 30px;
+    display: flex;
+    align-items: center;
+    transition-property: all;
 }
 
 #outerbox.active {
-  background-color: rgba(243, 211, 200, 0.916);
+    background-color: rgba(243, 211, 200, 0.916);
 }
 
 #innerbox {
-  height: 20px;
-  width: 20px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: white;
-  background-color: rgb(86, 102, 189);
-  border-radius: 30px;
-  margin-left: 6%;
-  transition-property: all;
-  transition-duration: 0.3s;
+    height: 20px;
+    width: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    background-color: rgb(86, 102, 189);
+    border-radius: 30px;
+    margin-left: 6%;
+    transition-property: all;
+    transition-duration: 0.3s;
 }
 
 #innerbox.active {
-  margin-left: 50%;
-  background-color: rgba(141, 110, 72, 0.912);
+    margin-left: 50%;
+    background-color: rgba(141, 110, 72, 0.912);
 }
 
 #darkmode {
-  color: rgba(0, 4, 7, 0.578);
-  font-size: smaller;
-  font-weight: 600;
-  line-height: 1.1;
+    color: rgba(0, 4, 7, 0.578);
+    font-size: smaller;
+    font-weight: 600;
+    line-height: 1.1;
 }
 
 #darkmode.active {
-  color: white;
+    color: white;
 }
 
 /* Disabled State */
 .extension-disabled {
-  opacity: 0.5;
-  pointer-events: none;
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 .extension-disabled-message {
-  padding: 16px;
-  text-align: center;
-  color: var(--text-secondary);
-  background: var(--bg-secondary);
-  border-radius: 8px;
-  margin: 16px;
+    padding: 16px;
+    text-align: center;
+    color: var(--text-secondary);
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    margin: 16px;
 }
 
 .extension-disabled-message svg {
-  opacity: 0.5;
-  margin-bottom: 8px;
+    opacity: 0.5;
+    margin-bottom: 8px;
 }
 
 /* Utility Classes */
 .hidden {
-  display: none !important;
+    display: none !important;
 }
 
 /* Scrollbar */
 ::-webkit-scrollbar {
-  width: 8px;
+    width: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--bg);
+    background: var(--bg);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 4px;
+    background: var(--border);
+    border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--secondary);
+    background: var(--secondary);
+}
+
+.domains-list-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px;
+    margin-top: 8px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    min-height: 42px;
+    align-items: center;
+    cursor: text;
+    transition: all 0.2s ease;
+}
+
+.domains-list-container:hover {
+    border-color: var(--text-secondary);
+}
+
+.domains-list-container:focus-within {
+    border-color: var(--primary);
+    background: var(--bg);
+    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.1);
+}
+
+.tag {
+    background: var(--primary);
+    color: white;
+    padding: 4px 10px;
+    border-radius: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    user-select: none;
+    animation: fadeIn 0.2s ease;
+}
+
+.tag-input {
+    border: none !important;
+    outline: none !important;
+    background: transparent !important;
+    flex: 1;
+    min-width: 140px;
+    padding: 4px 6px !important;
+    font-size: 14px;
+    color: var(--text);
+    font-family: inherit;
+}
+
+.tag-input::placeholder {
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
+.tag button {
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 2px;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.tag button:hover {
+    opacity: 1;
+}
+
+.tag button:focus {
+    outline: none;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,212 +1,363 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>AI Context Assistant</title>
+        <link rel="stylesheet" href="popup.css" />
+    </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Context Assistant</title>
-  <link rel="stylesheet" href="popup.css">
-</head>
+    <body>
+        <div class="container">
+            <!-- Header -->
+            <header class="header">
+                <div class="logo">
+                    <svg
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M12 2L2 7L12 12L22 7L12 2Z"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                        <path
+                            d="M2 17L12 22L22 17"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                        <path
+                            d="M2 12L12 17L22 12"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        />
+                    </svg>
+                    <h1>SuggestPilot - AI Context Assistant</h1>
+                </div>
 
-<body>
-  <div class="container">
-    <!-- Header -->
-    <header class="header">
-      <div class="logo">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round" />
-          <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round" />
-          <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round" />
-        </svg>
-        <h1>SuggestPilot - AI Context Assistant</h1>
-      </div>
+                <div style="display: flex; align-items: center; gap: 8px">
+                    <div
+                        class="toggles"
+                        style="display: flex; flex-direction: column; gap: 3px"
+                    >
+                        <div
+                            class="theme-toggle"
+                            style="display: flex; gap: 8px"
+                        >
+                            <div>
+                                <div id="outerbox">
+                                    <div id="innerbox">
+                                        <p id="text">X</p>
+                                    </div>
+                                </div>
+                            </div>
 
-      <div style="display: flex;  align-items: center; gap: 8px;">
-        <div class="toggles" style="display: flex; flex-direction: column; gap:3px;">
-          <div class="theme-toggle" style="display: flex ; gap : 8px">
+                            <p id="darkmode">Dark Mode</p>
+                        </div>
+                        <div
+                            class="toggle-container"
+                            title="Enable/Disable Extension"
+                        >
+                            <label class="toggle-switch">
+                                <input
+                                    type="checkbox"
+                                    id="extensionToggle"
+                                    checked
+                                />
+                                <span class="toggle-slider"></span>
+                            </label>
+                            <span id="toggleStatus" class="toggle-status"
+                                >ON</span
+                            >
+                        </div>
+                    </div>
+                    <button id="settingsBtn" class="icon-btn" title="Settings">
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <circle cx="12" cy="12" r="3"></circle>
+                            <path
+                                d="M12 1v6m0 6v6m6-12h-6m-6 0H1m21 6h-6m-6 0H4"
+                            ></path>
+                        </svg>
+                    </button>
+                </div>
+            </header>
 
-            <div> 
-
-            <div id="outerbox">
-            <div id="innerbox">
-            <p id="text">X</p>
+            <!-- Not Configured View -->
+            <div id="notConfiguredView" class="view hidden">
+                <div class="empty-state">
+                    <svg
+                        width="48"
+                        height="48"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                    >
+                        <path
+                            d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"
+                        ></path>
+                    </svg>
+                    <h2>Welcome to AI Context Assistant</h2>
+                    <p>
+                        To get started, please configure your OpenAI API key in
+                        settings.
+                    </p>
+                    <button id="goToSettingsBtn" class="btn btn-primary">
+                        Configure Settings
+                    </button>
+                </div>
             </div>
+
+            <!-- Main View -->
+            <div id="mainView" class="view hidden">
+                <!-- Status Bar -->
+                <div id="statusBar" class="status-bar hidden">
+                    <span id="statusText"></span>
+                </div>
+
+                <!-- Suggestions -->
+                <div id="suggestionsContainer" class="suggestions-container">
+                    <div id="loadingState" class="loading-state hidden">
+                        <div class="spinner"></div>
+                        <p>Analyzing context...</p>
+                    </div>
+
+                    <div id="emptyState" class="empty-state">
+                        <svg
+                            width="48"
+                            height="48"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <circle cx="11" cy="11" r="8"></circle>
+                            <path d="m21 21-4.35-4.35"></path>
+                        </svg>
+                        <p>
+                            Focus on an input field to get AI-powered
+                            suggestions
+                        </p>
+                    </div>
+
+                    <div
+                        id="suggestionsList"
+                        class="suggestions-list hidden"
+                    ></div>
+                </div>
+
+                <!-- Actions -->
+                <div class="actions">
+                    <button id="refreshBtn" class="btn btn-secondary">
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <path
+                                d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"
+                            />
+                        </svg>
+                        Refresh Suggestions
+                    </button>
+                </div>
             </div>
 
+            <!-- Settings View -->
+            <div id="settingsView" class="view hidden">
+                <div class="settings-header">
+                    <button id="backBtn" class="icon-btn">
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <path d="M19 12H5M12 19l-7-7 7-7" />
+                        </svg>
+                    </button>
+                    <h2>Settings</h2>
+                </div>
+
+                <div class="settings-content">
+                    <!-- API Key Section -->
+                    <section class="settings-section">
+                        <h3>Groq Cloud Configuration</h3>
+
+                        <div class="form-group">
+                            <label for="apiKeyInput">Groq API Key</label>
+                            <div class="input-with-btn">
+                                <input
+                                    type="password"
+                                    id="apiKeyInput"
+                                    placeholder="gsk_..."
+                                    autocomplete="off"
+                                />
+                                <button
+                                    id="toggleApiKeyBtn"
+                                    class="icon-btn"
+                                    type="button"
+                                >
+                                    <svg
+                                        width="18"
+                                        height="18"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        stroke-width="2"
+                                    >
+                                        <path
+                                            d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"
+                                        ></path>
+                                        <circle cx="12" cy="12" r="3"></circle>
+                                    </svg>
+                                </button>
+                            </div>
+                            <small
+                                >Get free key at
+                                <a
+                                    href="https://console.groq.com/keys"
+                                    target="_blank"
+                                    style="color: #4a90e2"
+                                    >console.groq.com/keys</a
+                                >
+                                - No credit card required!</small
+                            >
+                        </div>
+
+                        <div class="form-group">
+                            <label for="modelSelect">Model</label>
+                            <select id="modelSelect">
+                                <option value="llama-3.1-8b-instant">
+                                    Llama 3.1 8B Instant (Fastest available)
+                                </option>
+                            </select>
+                            <small>Fast 8B parameter model</small>
+                        </div>
+
+                        <button
+                            id="testConnectionBtn"
+                            class="btn btn-secondary"
+                        >
+                            Test Connection
+                        </button>
+                        <div
+                            id="connectionStatus"
+                            class="connection-status hidden"
+                        ></div>
+                    </section>
+
+                    <!-- Features Section -->
+                    <section class="settings-section">
+                        <h3>Features</h3>
+
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    id="enableHistoryTracking"
+                                />
+                                <span>Enable History Tracking</span>
+                            </label>
+                            <small
+                                >Store recent searches for better
+                                suggestions</small
+                            >
+                        </div>
+
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="enableTabAnalysis" />
+                                <span>Enable Tab Analysis</span>
+                            </label>
+                            <small>Analyze open tabs for context</small>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="enableAiChatMode" />
+                                <span>Enable AI Chat Mode</span>
+                            </label>
+                            <small>Provide prompt refinement suggestions</small>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="add-label">Blocked Sites</label>
+                            <small
+                                >Suggestions will be disabled on these
+                                domains.</small
+                            >
+
+                            <div
+                                class="domains-list-container"
+                                id="domainsContainer"
+                            >
+                                <input
+                                    type="text"
+                                    placeholder="Add a domain (e.g. google.com)..."
+                                    class="tag-input"
+                                    id="blockedDomainsInput"
+                                />
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- About Section -->
+                    <section class="settings-section">
+                        <h3>About</h3>
+                        <p class="about-text">
+                            AI Context Assistant v1.0.0<br />
+                            Intelligent browser extension for context-aware
+                            suggestions
+                        </p>
+                        <div class="links">
+                            <a
+                                href="https://github.com/Shantanugupta43/SuggestPilot"
+                                target="_blank"
+                                >GitHub</a
+                            >
+                            <a
+                                href="https://github.com/Shantanugupta43/SuggestPilot/issues"
+                                target="_blank"
+                                >Report Issue</a
+                            >
+                        </div>
+                    </section>
+
+                    <!-- Actions -->
+                    <div class="settings-actions">
+                        <button id="saveSettingsBtn" class="btn btn-primary">
+                            Save Settings
+                        </button>
+                        <button id="clearDataBtn" class="btn btn-danger">
+                            Clear All Data
+                        </button>
+                    </div>
+                </div>
             </div>
-
-            <p  id="darkmode" >Dark Mode</p>
-
-            
-          </div>
-          <div class="toggle-container" title="Enable/Disable Extension">
-            <label class="toggle-switch">
-              <input type="checkbox" id="extensionToggle" checked>
-              <span class="toggle-slider"></span>
-            </label>
-            <span id="toggleStatus" class="toggle-status">ON</span>
-          </div>
-        </div>
-        <button id="settingsBtn" class="icon-btn" title="Settings">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="3"></circle>
-            <path d="M12 1v6m0 6v6m6-12h-6m-6 0H1m21 6h-6m-6 0H4"></path>
-          </svg>
-        </button>
-      </div>
-    </header>
-
-    <!-- Not Configured View -->
-    <div id="notConfiguredView" class="view hidden">
-      <div class="empty-state">
-        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-        </svg>
-        <h2>Welcome to AI Context Assistant</h2>
-        <p>To get started, please configure your OpenAI API key in settings.</p>
-        <button id="goToSettingsBtn" class="btn btn-primary">Configure Settings</button>
-      </div>
-    </div>
-
-    <!-- Main View -->
-    <div id="mainView" class="view hidden">
-      <!-- Status Bar -->
-      <div id="statusBar" class="status-bar hidden">
-        <span id="statusText"></span>
-      </div>
-
-      <!-- Suggestions -->
-      <div id="suggestionsContainer" class="suggestions-container">
-        <div id="loadingState" class="loading-state hidden">
-          <div class="spinner"></div>
-          <p>Analyzing context...</p>
         </div>
 
-        <div id="emptyState" class="empty-state">
-          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="11" cy="11" r="8"></circle>
-            <path d="m21 21-4.35-4.35"></path>
-          </svg>
-          <p>Focus on an input field to get AI-powered suggestions</p>
-        </div>
-
-        <div id="suggestionsList" class="suggestions-list hidden"></div>
-      </div>
-
-      <!-- Actions -->
-      <div class="actions">
-        <button id="refreshBtn" class="btn btn-secondary">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
-          </svg>
-          Refresh Suggestions
-        </button>
-      </div>
-    </div>
-
-    <!-- Settings View -->
-    <div id="settingsView" class="view hidden">
-      <div class="settings-header">
-        <button id="backBtn" class="icon-btn">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M19 12H5M12 19l-7-7 7-7" />
-          </svg>
-        </button>
-        <h2>Settings</h2>
-      </div>
-
-      <div class="settings-content">
-        <!-- API Key Section -->
-        <section class="settings-section">
-          <h3>Groq Cloud Configuration</h3>
-
-          <div class="form-group">
-            <label for="apiKeyInput">Groq API Key</label>
-            <div class="input-with-btn">
-              <input type="password" id="apiKeyInput" placeholder="gsk_..." autocomplete="off">
-              <button id="toggleApiKeyBtn" class="icon-btn" type="button">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                  <circle cx="12" cy="12" r="3"></circle>
-                </svg>
-              </button>
-            </div>
-            <small>Get free key at <a href="https://console.groq.com/keys" target="_blank"
-                style="color: #4A90E2;">console.groq.com/keys</a> - No credit card required!</small>
-          </div>
-
-          <div class="form-group">
-            <label for="modelSelect">Model</label>
-            <select id="modelSelect">
-              <option value="llama-3.1-8b-instant">Llama 3.1 8B Instant (Fastest available)</option>
-            </select>
-            <small>Fast 8B parameter model</small>
-          </div>
-
-          <button id="testConnectionBtn" class="btn btn-secondary">Test Connection</button>
-          <div id="connectionStatus" class="connection-status hidden"></div>
-        </section>
-
-        <!-- Features Section -->
-        <section class="settings-section">
-          <h3>Features</h3>
-
-          <div class="form-group">
-            <label class="checkbox-label">
-              <input type="checkbox" id="enableHistoryTracking">
-              <span>Enable History Tracking</span>
-            </label>
-            <small>Store recent searches for better suggestions</small>
-          </div>
-
-          <div class="form-group">
-            <label class="checkbox-label">
-              <input type="checkbox" id="enableTabAnalysis">
-              <span>Enable Tab Analysis</span>
-            </label>
-            <small>Analyze open tabs for context</small>
-          </div>
-
-          <div class="form-group">
-            <label class="checkbox-label">
-              <input type="checkbox" id="enableAiChatMode">
-              <span>Enable AI Chat Mode</span>
-            </label>
-            <small>Provide prompt refinement suggestions</small>
-
-
-
-          </div>
-
-
-        </section>
-
-        <!-- About Section -->
-        <section class="settings-section">
-          <h3>About</h3>
-          <p class="about-text">
-            AI Context Assistant v1.0.0<br>
-            Intelligent browser extension for context-aware suggestions
-          </p>
-          <div class="links">
-            <a href="https://github.com/Shantanugupta43/SuggestPilot" target="_blank">GitHub</a>
-            <a href="https://github.com/Shantanugupta43/SuggestPilot/issues" target="_blank">Report Issue</a>
-          </div>
-        </section>
-
-        <!-- Actions -->
-        <div class="settings-actions">
-          <button id="saveSettingsBtn" class="btn btn-primary">Save Settings</button>
-          <button id="clearDataBtn" class="btn btn-danger">Clear All Data</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <script type="module" src="popup.js"></script>
-</body>
-
+        <script type="module" src="popup.js"></script>
+    </body>
 </html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -147,14 +147,17 @@ function setupEventListeners() {
   elements.blockedDomains.addEventListener("keydown", (event) => {
     if (event.key == "Enter") {
       event.preventDefault();
-      let domain = event.target.value.trim();
-      if (domain != "" && !currentConfig.blockedDomains.includes(domain)) {
+      let cleanDomain = extractDomain(event.target.value);
+      if (cleanDomain && !currentConfig.blockedDomains.includes(cleanDomain)) {
         currentConfig.blockedDomains = [
           ...currentConfig.blockedDomains,
-          domain,
+          cleanDomain,
         ];
+
         event.target.value = "";
         renderTags();
+      } else if (!cleanDomain) {
+        console.error("Invalid domain/s entered.");
       }
     }
   });
@@ -344,6 +347,36 @@ async function toggleExtension() {
   } catch (error) {
     console.error("Failed to toggle extension:", error);
     showStatus("Failed to toggle extension", "error");
+  }
+}
+
+/**
+ * Sanitizes user input to extract just the base domain.
+ * "https://www.reddit.com/r/webdev" -> "reddit.com"
+ * "linkedin.com/feed/" -> "linkedin.com"
+ */
+function extractDomain(input) {
+  let urlString = input.toLowerCase().trim();
+
+  if (!urlString.startsWith("https://") && !urlString.startsWith("http://")) {
+    urlString = "https://" + urlString;
+  }
+
+  try {
+    const url = new URL(urlString);
+    let hostname = url.hostname;
+
+    if (!hostname.includes(".") || hostname.includes(" ")) {
+      return null;
+    }
+
+    if (hostname.startsWith("www.")) {
+      hostname = hostname.substring(4);
+    }
+
+    return hostname;
+  } catch (error) {
+    return null;
   }
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -5,43 +5,52 @@
 
 // Views
 const views = {
-  notConfigured: document.getElementById('notConfiguredView'),
-  main: document.getElementById('mainView'),
-  settings: document.getElementById('settingsView')
+  notConfigured: document.getElementById("notConfiguredView"),
+  main: document.getElementById("mainView"),
+  settings: document.getElementById("settingsView"),
 };
 
 // Elements
 const elements = {
   // Main view
-  statusBar: document.getElementById('statusBar'),
-  statusText: document.getElementById('statusText'),
-  loadingState: document.getElementById('loadingState'),
-  emptyState: document.getElementById('emptyState'),
-  suggestionsList: document.getElementById('suggestionsList'),
-  refreshBtn: document.getElementById('refreshBtn'),
-  
+  statusBar: document.getElementById("statusBar"),
+  statusText: document.getElementById("statusText"),
+  loadingState: document.getElementById("loadingState"),
+  emptyState: document.getElementById("emptyState"),
+  suggestionsList: document.getElementById("suggestionsList"),
+  refreshBtn: document.getElementById("refreshBtn"),
+
   // Toggle
-  extensionToggle: document.getElementById('extensionToggle'),
-  toggleStatus: document.getElementById('toggleStatus'),
-  
+  extensionToggle: document.getElementById("extensionToggle"),
+  toggleStatus: document.getElementById("toggleStatus"),
+
   // Settings view
-  settingsBtn: document.getElementById('settingsBtn'),
-  backBtn: document.getElementById('backBtn'),
-  goToSettingsBtn: document.getElementById('goToSettingsBtn'),
-  apiKeyInput: document.getElementById('apiKeyInput'),
-  toggleApiKeyBtn: document.getElementById('toggleApiKeyBtn'),
-  modelSelect: document.getElementById('modelSelect'),
-  testConnectionBtn: document.getElementById('testConnectionBtn'),
-  connectionStatus: document.getElementById('connectionStatus'),
-  enableHistoryTracking: document.getElementById('enableHistoryTracking'),
-  enableTabAnalysis: document.getElementById('enableTabAnalysis'),
-  enableAiChatMode: document.getElementById('enableAiChatMode'),
-  saveSettingsBtn: document.getElementById('saveSettingsBtn'),
-  clearDataBtn: document.getElementById('clearDataBtn')
+  settingsBtn: document.getElementById("settingsBtn"),
+  backBtn: document.getElementById("backBtn"),
+  goToSettingsBtn: document.getElementById("goToSettingsBtn"),
+  apiKeyInput: document.getElementById("apiKeyInput"),
+  toggleApiKeyBtn: document.getElementById("toggleApiKeyBtn"),
+  modelSelect: document.getElementById("modelSelect"),
+  testConnectionBtn: document.getElementById("testConnectionBtn"),
+  connectionStatus: document.getElementById("connectionStatus"),
+  enableHistoryTracking: document.getElementById("enableHistoryTracking"),
+  enableTabAnalysis: document.getElementById("enableTabAnalysis"),
+  enableAiChatMode: document.getElementById("enableAiChatMode"),
+  blockedDomains: document.getElementById("blockedDomainsInput"),
+  domainsContainer: document.getElementById("domainsContainer"),
+  saveSettingsBtn: document.getElementById("saveSettingsBtn"),
+  clearDataBtn: document.getElementById("clearDataBtn"),
 };
 
 // State
-let currentConfig = { isConfigured: false, model: "llama-3.1-8b-instant", enableHistoryTracking: true, enableTabAnalysis: true, enableAiChatMode: true };
+let currentConfig = {
+  isConfigured: false,
+  model: "llama-3.1-8b-instant",
+  enableHistoryTracking: true,
+  enableTabAnalysis: true,
+  enableAiChatMode: true,
+  blockedDomains: ["linkedin.com"],
+};
 let currentSuggestions = null;
 let extensionEnabled = true;
 
@@ -55,19 +64,19 @@ async function initialize() {
     setupEventListeners();
 
     if (currentConfig && currentConfig.isConfigured) {
-      showView('main');
+      showView("main");
       if (extensionEnabled) {
         await loadSuggestions();
       } else {
         showDisabledState();
       }
     } else {
-      showView('notConfigured');
+      showView("notConfigured");
     }
   } catch (error) {
     // Last-resort catch: always show notConfigured rather than blank popup
-    console.error('Initialization error:', error);
-    showView('notConfigured');
+    console.error("Initialization error:", error);
+    showView("notConfigured");
   }
 }
 
@@ -76,17 +85,17 @@ async function initialize() {
  */
 async function loadConfig() {
   try {
-    const response = await chrome.runtime.sendMessage({ 
-      action: 'getConfig' 
+    const response = await chrome.runtime.sendMessage({
+      action: "getConfig",
     });
-    
+
     if (response && response.success && response.config) {
       currentConfig = response.config;
       populateSettings();
     }
     // If response.success is false or config missing, keep the safe default
   } catch (error) {
-    console.error('Failed to load config:', error);
+    console.error("Failed to load config:", error);
     // Keep safe default — do NOT show error here, initialize() will show notConfigured
   }
 }
@@ -96,12 +105,12 @@ async function loadConfig() {
  */
 async function loadExtensionState() {
   try {
-    const stored = await chrome.storage.local.get('extensionEnabled');
+    const stored = await chrome.storage.local.get("extensionEnabled");
     extensionEnabled = stored.extensionEnabled ?? true;
     elements.extensionToggle.checked = extensionEnabled;
     updateToggleStatus();
   } catch (error) {
-    console.error('Failed to load extension state:', error);
+    console.error("Failed to load extension state:", error);
   }
 }
 
@@ -109,8 +118,8 @@ async function loadExtensionState() {
  * Show specific view
  */
 function showView(viewName) {
-  Object.values(views).forEach(view => view.classList.add('hidden'));
-  views[viewName]?.classList.remove('hidden');
+  Object.values(views).forEach((view) => view.classList.add("hidden"));
+  views[viewName]?.classList.remove("hidden");
 }
 
 /**
@@ -118,19 +127,37 @@ function showView(viewName) {
  */
 function setupEventListeners() {
   // Navigation
-  elements.settingsBtn.addEventListener('click', () => showView('settings'));
-  elements.backBtn.addEventListener('click', () => showView('main'));
-  elements.goToSettingsBtn.addEventListener('click', () => showView('settings'));
-  
+  elements.settingsBtn.addEventListener("click", () => showView("settings"));
+  elements.backBtn.addEventListener("click", () => showView("main"));
+  elements.goToSettingsBtn.addEventListener("click", () =>
+    showView("settings"),
+  );
+
   // Extension Toggle
-  elements.extensionToggle.addEventListener('change', toggleExtension);
-  
+  elements.extensionToggle.addEventListener("change", toggleExtension);
+
   // Actions
-  elements.refreshBtn.addEventListener('click', loadSuggestions);
-  elements.toggleApiKeyBtn.addEventListener('click', toggleApiKeyVisibility);
-  elements.testConnectionBtn.addEventListener('click', testConnection);
-  elements.saveSettingsBtn.addEventListener('click', saveSettings);
-  elements.clearDataBtn.addEventListener('click', clearData);
+  elements.refreshBtn.addEventListener("click", loadSuggestions);
+  elements.toggleApiKeyBtn.addEventListener("click", toggleApiKeyVisibility);
+  elements.testConnectionBtn.addEventListener("click", testConnection);
+  elements.saveSettingsBtn.addEventListener("click", saveSettings);
+  elements.clearDataBtn.addEventListener("click", clearData);
+
+  // Blocked domains list
+  elements.blockedDomains.addEventListener("keydown", (event) => {
+    if (event.key == "Enter") {
+      event.preventDefault();
+      let domain = event.target.value.trim();
+      if (domain != "" && !currentConfig.blockedDomains.includes(domain)) {
+        currentConfig.blockedDomains = [
+          ...currentConfig.blockedDomains,
+          domain,
+        ];
+        event.target.value = "";
+        renderTags();
+      }
+    }
+  });
 }
 
 /**
@@ -139,22 +166,22 @@ function setupEventListeners() {
 async function loadSuggestions() {
   try {
     showLoading();
-    
-    const response = await chrome.runtime.sendMessage({ 
-      action: 'generateSuggestions',
-      data: {}
+
+    const response = await chrome.runtime.sendMessage({
+      action: "generateSuggestions",
+      data: {},
     });
-    
+
     if (response.success) {
       currentSuggestions = response;
       displaySuggestions(response);
     } else {
-      showStatus(response.error || 'Failed to generate suggestions', 'error');
+      showStatus(response.error || "Failed to generate suggestions", "error");
       showEmpty();
     }
   } catch (error) {
-    console.error('Failed to load suggestions:', error);
-    showStatus('Failed to load suggestions', 'error');
+    console.error("Failed to load suggestions:", error);
+    showStatus("Failed to load suggestions", "error");
     showEmpty();
   }
 }
@@ -164,28 +191,28 @@ async function loadSuggestions() {
  */
 function displaySuggestions(data) {
   const { reason, suggestions } = data;
-  
-  elements.loadingState.classList.add('hidden');
-  elements.emptyState.classList.add('hidden');
-  
+
+  elements.loadingState.classList.add("hidden");
+  elements.emptyState.classList.add("hidden");
+
   if (!suggestions || suggestions.length === 0) {
     showEmpty();
     if (reason) {
-      showStatus(reason, 'info');
+      showStatus(reason, "info");
     }
     return;
   }
-  
-  elements.suggestionsList.classList.remove('hidden');
-  elements.suggestionsList.innerHTML = '';
-  
+
+  elements.suggestionsList.classList.remove("hidden");
+  elements.suggestionsList.innerHTML = "";
+
   suggestions.forEach((suggestion, index) => {
     const card = createSuggestionCard(suggestion, index);
     elements.suggestionsList.appendChild(card);
   });
-  
+
   if (reason) {
-    showStatus(reason, 'success');
+    showStatus(reason, "success");
   }
 }
 
@@ -193,30 +220,31 @@ function displaySuggestions(data) {
  * Create suggestion card
  */
 function createSuggestionCard(suggestion, index) {
-  const card = document.createElement('div');
-  card.className = 'suggestion-card';
-  
+  const card = document.createElement("div");
+  card.className = "suggestion-card";
+
   // Handle both string and object formats
-  const text = typeof suggestion === 'string' ? suggestion : suggestion.text;
-  const derivation = typeof suggestion === 'object' ? suggestion.derivation : null;
-  
-  const textEl = document.createElement('div');
-  textEl.className = 'suggestion-text';
+  const text = typeof suggestion === "string" ? suggestion : suggestion.text;
+  const derivation =
+    typeof suggestion === "object" ? suggestion.derivation : null;
+
+  const textEl = document.createElement("div");
+  textEl.className = "suggestion-text";
   textEl.textContent = text;
-  
+
   card.appendChild(textEl);
-  
+
   // Add derivation explanation if available
   if (derivation) {
-    const derivationEl = document.createElement('div');
-    derivationEl.className = 'suggestion-derivation';
+    const derivationEl = document.createElement("div");
+    derivationEl.className = "suggestion-derivation";
     derivationEl.innerHTML = `<strong>Why:</strong> ${derivation}`;
     card.appendChild(derivationEl);
   }
-  
+
   // Add click handler to insert suggestion
-  card.addEventListener('click', () => insertSuggestion(text));
-  
+  card.addEventListener("click", () => insertSuggestion(text));
+
   return card;
 }
 
@@ -225,22 +253,25 @@ function createSuggestionCard(suggestion, index) {
  */
 async function insertSuggestion(text) {
   try {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    
-    const response = await chrome.tabs.sendMessage(tab.id, {
-      action: 'insertSuggestion',
-      data: { text }
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
     });
-    
+
+    const response = await chrome.tabs.sendMessage(tab.id, {
+      action: "insertSuggestion",
+      data: { text },
+    });
+
     if (response.success) {
-      showStatus('Suggestion inserted', 'success');
+      showStatus("Suggestion inserted", "success");
       setTimeout(() => window.close(), 1000);
     } else {
-      showStatus('Failed to insert suggestion', 'error');
+      showStatus("Failed to insert suggestion", "error");
     }
   } catch (error) {
-    console.error('Failed to insert suggestion:', error);
-    showStatus('Failed to insert suggestion', 'error');
+    console.error("Failed to insert suggestion:", error);
+    showStatus("Failed to insert suggestion", "error");
   }
 }
 
@@ -248,28 +279,28 @@ async function insertSuggestion(text) {
  * Show loading state
  */
 function showLoading() {
-  elements.loadingState.classList.remove('hidden');
-  elements.emptyState.classList.add('hidden');
-  elements.suggestionsList.classList.add('hidden');
+  elements.loadingState.classList.remove("hidden");
+  elements.emptyState.classList.add("hidden");
+  elements.suggestionsList.classList.add("hidden");
 }
 
 /**
  * Show empty state
  */
 function showEmpty() {
-  elements.loadingState.classList.add('hidden');
-  elements.emptyState.classList.remove('hidden');
-  elements.suggestionsList.classList.add('hidden');
+  elements.loadingState.classList.add("hidden");
+  elements.emptyState.classList.remove("hidden");
+  elements.suggestionsList.classList.add("hidden");
 }
 
 /**
  * Show disabled state
  */
 function showDisabledState() {
-  elements.loadingState.classList.add('hidden');
-  elements.suggestionsList.classList.add('hidden');
-  elements.emptyState.classList.remove('hidden');
-  
+  elements.loadingState.classList.add("hidden");
+  elements.suggestionsList.classList.add("hidden");
+  elements.emptyState.classList.remove("hidden");
+
   const emptyState = elements.emptyState;
   emptyState.innerHTML = `
     <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -286,84 +317,107 @@ function showDisabledState() {
  */
 async function toggleExtension() {
   extensionEnabled = elements.extensionToggle.checked;
-  
+
   try {
     await chrome.storage.local.set({ extensionEnabled });
     updateToggleStatus();
-    
+
     // Notify content script
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    chrome.tabs.sendMessage(tab.id, {
-      action: 'toggleExtension',
-      data: { enabled: extensionEnabled }
-    }).catch(() => {});
-    
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    chrome.tabs
+      .sendMessage(tab.id, {
+        action: "toggleExtension",
+        data: { enabled: extensionEnabled },
+      })
+      .catch(() => {});
+
     if (extensionEnabled) {
-      showStatus('Extension enabled', 'success');
+      showStatus("Extension enabled", "success");
       await loadSuggestions();
     } else {
-      showStatus('Extension disabled', 'info');
+      showStatus("Extension disabled", "info");
       showDisabledState();
     }
   } catch (error) {
-    console.error('Failed to toggle extension:', error);
-    showStatus('Failed to toggle extension', 'error');
+    console.error("Failed to toggle extension:", error);
+    showStatus("Failed to toggle extension", "error");
   }
 }
 
 /**
  * dark mode toggle
- *  */ 
+ *  */
 
-const sign = document.getElementById('text');
+const sign = document.getElementById("text");
 const outer = document.getElementById("outerbox");
 const inner = document.getElementById("innerbox");
-const text =document.getElementById("darkmode")
+const text = document.getElementById("darkmode");
 
 function changeText() {
   if (sign.textContent == "X") {
     sign.textContent = "✔";
     outer.classList.toggle("active");
     inner.classList.toggle("active");
-    document.body.classList.add('dark');
+    document.body.classList.add("dark");
     text.classList.toggle("active");
-    
-
   } else {
     sign.textContent = "X";
     outer.classList.toggle("active");
     inner.classList.toggle("active");
-    document.body.classList.remove('dark');
-     text.classList.toggle("active");
+    document.body.classList.remove("dark");
+    text.classList.toggle("active");
   }
 }
 
-outer.addEventListener('click', changeText);
-
-
-
-
-
+outer.addEventListener("click", changeText);
 
 /**
  * Update toggle status text
  */
 function updateToggleStatus() {
-  elements.toggleStatus.textContent = extensionEnabled ? 'ON' : 'OFF';
-  elements.toggleStatus.style.color = extensionEnabled ? 'var(--success)' : 'var(--secondary)';
+  elements.toggleStatus.textContent = extensionEnabled ? "ON" : "OFF";
+  elements.toggleStatus.style.color = extensionEnabled
+    ? "var(--success)"
+    : "var(--secondary)";
 }
 
 /**
  * Show status message
  */
-function showStatus(message, type = 'info') {
+function showStatus(message, type = "info") {
   elements.statusText.textContent = message;
   elements.statusBar.className = `status-bar ${type}`;
-  elements.statusBar.classList.remove('hidden');
-  
+  elements.statusBar.classList.remove("hidden");
+
   setTimeout(() => {
-    elements.statusBar.classList.add('hidden');
+    elements.statusBar.classList.add("hidden");
   }, 5000);
+}
+
+/**
+ *
+ */
+function renderTags() {
+  elements.domainsContainer.querySelectorAll(".tag").forEach((tag) => {
+    tag.remove();
+  });
+  currentConfig.blockedDomains.forEach((domain, index) => {
+    const tag = document.createElement("div");
+    tag.className = "tag";
+    tag.innerHTML = `
+          ${domain}
+          <button type="button" data-index="${index}">&times;</button>
+        `;
+    tag.querySelector("button").addEventListener("click", () => {
+      currentConfig.blockedDomains.splice(index, 1);
+      renderTags();
+    });
+
+    elements.domainsContainer.insertBefore(tag, elements.blockedDomains);
+  });
 }
 
 /**
@@ -371,11 +425,20 @@ function showStatus(message, type = 'info') {
  */
 function populateSettings() {
   if (!currentConfig) return;
-  
-  elements.modelSelect.value = currentConfig.model || 'llama-3.1-8b-instant';
-  elements.enableHistoryTracking.checked = currentConfig.enableHistoryTracking ?? true;
+
+  elements.modelSelect.value = currentConfig.model || "llama-3.1-8b-instant";
+  elements.enableHistoryTracking.checked =
+    currentConfig.enableHistoryTracking ?? true;
   elements.enableTabAnalysis.checked = currentConfig.enableTabAnalysis ?? true;
   elements.enableAiChatMode.checked = currentConfig.enableAiChatMode ?? true;
+  if (
+    !currentConfig.blockedDomains ||
+    !Array.isArray(currentConfig.blockedDomains)
+  ) {
+    currentConfig.blockedDomains = ["linkedin.com"];
+  }
+
+  renderTags();
 }
 
 /**
@@ -383,7 +446,7 @@ function populateSettings() {
  */
 function toggleApiKeyVisibility() {
   const input = elements.apiKeyInput;
-  input.type = input.type === 'password' ? 'text' : 'password';
+  input.type = input.type === "password" ? "text" : "password";
 }
 
 /**
@@ -392,29 +455,30 @@ function toggleApiKeyVisibility() {
 async function testConnection() {
   try {
     elements.testConnectionBtn.disabled = true;
-    elements.testConnectionBtn.textContent = 'Testing...';
-    elements.connectionStatus.classList.add('hidden');
-    
-    const response = await chrome.runtime.sendMessage({ 
-      action: 'testConnection' 
+    elements.testConnectionBtn.textContent = "Testing...";
+    elements.connectionStatus.classList.add("hidden");
+
+    const response = await chrome.runtime.sendMessage({
+      action: "testConnection",
     });
-    
-    elements.connectionStatus.classList.remove('hidden');
-    
+
+    elements.connectionStatus.classList.remove("hidden");
+
     if (response.success) {
-      elements.connectionStatus.textContent = '✔ Connection successful';
-      elements.connectionStatus.className = 'connection-status success';
+      elements.connectionStatus.textContent = "✔ Connection successful";
+      elements.connectionStatus.className = "connection-status success";
     } else {
-      elements.connectionStatus.textContent = '✗ Connection failed';
-      elements.connectionStatus.className = 'connection-status error';
+      elements.connectionStatus.textContent = "✗ Connection failed";
+      elements.connectionStatus.className = "connection-status error";
     }
   } catch (error) {
-    elements.connectionStatus.classList.remove('hidden');
-    elements.connectionStatus.textContent = '✗ Connection failed: ' + error.message;
-    elements.connectionStatus.className = 'connection-status error';
+    elements.connectionStatus.classList.remove("hidden");
+    elements.connectionStatus.textContent =
+      "✗ Connection failed: " + error.message;
+    elements.connectionStatus.className = "connection-status error";
   } finally {
     elements.testConnectionBtn.disabled = false;
-    elements.testConnectionBtn.textContent = 'Test Connection';
+    elements.testConnectionBtn.textContent = "Test Connection";
   }
 }
 
@@ -424,43 +488,44 @@ async function testConnection() {
 async function saveSettings() {
   try {
     elements.saveSettingsBtn.disabled = true;
-    elements.saveSettingsBtn.textContent = 'Saving...';
-    
+    elements.saveSettingsBtn.textContent = "Saving...";
+
     // Save API key if provided
     const apiKey = elements.apiKeyInput.value.trim();
     if (apiKey) {
       await chrome.runtime.sendMessage({
-        action: 'setApiKey',
-        data: { apiKey }
+        action: "setApiKey",
+        data: { apiKey },
       });
-      elements.apiKeyInput.value = '';
+      elements.apiKeyInput.value = "";
     }
-    
+
     // Save other settings
     await chrome.runtime.sendMessage({
-      action: 'updateConfig',
+      action: "updateConfig",
       data: {
         updates: {
           model: elements.modelSelect.value,
           enableHistoryTracking: elements.enableHistoryTracking.checked,
           enableTabAnalysis: elements.enableTabAnalysis.checked,
-          enableAiChatMode: elements.enableAiChatMode.checked
-        }
-      }
+          enableAiChatMode: elements.enableAiChatMode.checked,
+          blockedDomains: currentConfig.blockedDomains,
+        },
+      },
     });
-    
-    showStatus('Settings saved successfully', 'success');
+
+    showStatus("Settings saved successfully", "success");
     await loadConfig();
-    
+
     if (currentConfig.isConfigured) {
-      setTimeout(() => showView('main'), 1000);
+      setTimeout(() => showView("main"), 1000);
     }
   } catch (error) {
-    console.error('Failed to save settings:', error);
-    showStatus('Failed to save settings: ' + error.message, 'error');
+    console.error("Failed to save settings:", error);
+    showStatus("Failed to save settings: " + error.message, "error");
   } finally {
     elements.saveSettingsBtn.disabled = false;
-    elements.saveSettingsBtn.textContent = 'Save Settings';
+    elements.saveSettingsBtn.textContent = "Save Settings";
   }
 }
 
@@ -468,23 +533,27 @@ async function saveSettings() {
  * Clear all data
  */
 async function clearData() {
-  if (!confirm('Are you sure you want to clear all data? This will remove your API key and settings.')) {
+  if (
+    !confirm(
+      "Are you sure you want to clear all data? This will remove your API key and settings.",
+    )
+  ) {
     return;
   }
-  
+
   try {
-    await chrome.runtime.sendMessage({ 
-      action: 'clearConfig' 
+    await chrome.runtime.sendMessage({
+      action: "clearConfig",
     });
-    
-    showStatus('All data cleared', 'success');
+
+    showStatus("All data cleared", "success");
     await loadConfig();
-    showView('notConfigured');
+    showView("notConfigured");
   } catch (error) {
-    console.error('Failed to clear data:', error);
-    showStatus('Failed to clear data', 'error');
+    console.error("Failed to clear data:", error);
+    showStatus("Failed to clear data", "error");
   }
 }
 
 // Initialize on load
-document.addEventListener('DOMContentLoaded', initialize);
+document.addEventListener("DOMContentLoaded", initialize);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -145,7 +145,7 @@ function setupEventListeners() {
 
   // Blocked domains list
   elements.blockedDomains.addEventListener("keydown", (event) => {
-    if (event.key == "Enter") {
+    if (event.key === "Enter") {
       event.preventDefault();
       let cleanDomain = extractDomain(event.target.value);
       if (cleanDomain && !currentConfig.blockedDomains.includes(cleanDomain)) {
@@ -241,7 +241,10 @@ function createSuggestionCard(suggestion, index) {
   if (derivation) {
     const derivationEl = document.createElement("div");
     derivationEl.className = "suggestion-derivation";
-    derivationEl.innerHTML = `<strong>Why:</strong> ${derivation}`;
+    const derivationLabelEl = document.createElement("strong");
+    derivationLabelEl.textContent = "Why:";
+    derivationEl.appendChild(derivationLabelEl);
+    derivationEl.appendChild(document.createTextNode(` ${derivation}`));
     card.appendChild(derivationEl);
   }
 
@@ -351,9 +354,11 @@ async function toggleExtension() {
 }
 
 /**
- * Sanitizes user input to extract just the base domain.
+ * Sanitizes user input to extract a normalized hostname.
+ * Removes the protocol/path and strips a leading "www." if present.
  * "https://www.reddit.com/r/webdev" -> "reddit.com"
  * "linkedin.com/feed/" -> "linkedin.com"
+ * "https://foo.reddit.com/r/webdev" -> "foo.reddit.com"
  */
 function extractDomain(input) {
   let urlString = input.toLowerCase().trim();
@@ -440,15 +445,17 @@ function renderTags() {
   currentConfig.blockedDomains.forEach((domain, index) => {
     const tag = document.createElement("div");
     tag.className = "tag";
-    tag.innerHTML = `
-          ${domain}
-          <button type="button" data-index="${index}">&times;</button>
-        `;
-    tag.querySelector("button").addEventListener("click", () => {
+    tag.appendChild(document.createTextNode(domain));
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.dataset.index = index;
+    removeButton.textContent = "×";
+    removeButton.setAttribute("aria-label", `Remove blocked domain ${domain}`);
+    removeButton.addEventListener("click", () => {
       currentConfig.blockedDomains.splice(index, 1);
       renderTags();
     });
-
+    tag.appendChild(removeButton);
     elements.domainsContainer.insertBefore(tag, elements.blockedDomains);
   });
 }


### PR DESCRIPTION
## **Summary**

Fixes two bugs in PR #41 that prevented the custom blocked domains feature from working.

**Root cause:**
- `getBlockedDomains()` was reading from the wrong storage key (`blockedDomains`) while data is actually stored under `config.blockedDomains`
- `initialize()` was calling `configManager.get("blockedDomains")` directly instead of using the existing `getBlockedDomains()` method

**Key changes:**
- `getBlockedDomains()` — updated to read from `chrome.storage.local.get('config')` and return `result?.config?.blockedDomains`
- `initialize()` — replaced `configManager.get("blockedDomains")` with `configManager.getBlockedDomains()`

**How to test:**
1. Open extension settings and add any domain (e.g. `github.com`)
2. Save settings
3. Open DevTools console on that domain — you should see `BLOCKED DOMAINS: ['github.com', ...]`
4. Verify the extension shows no suggestions on that page
5. Navigate to an unblocked site and confirm suggestions still work
