### PR TITLE
feat/ adds country field type detection with locale-based candidate

### DIFF
--- a/src/content/content-script.js
+++ b/src/content/content-script.js
@@ -42,7 +42,8 @@
     website:      ['website', 'portfolio', 'personal_site', 'homepage', 'personal_url'],
     experience_years: ['years_of_exp', 'yearsofexp', 'experience_years', 'yoe', 'years_experience'],
     issue_subject:     ['subject', 'issue_title', 'issuetitle', 'ticket_title', 'tickettitle', 'summary'],
-    issue_description: ['description', 'details', 'body', 'explain', 'steps_to_reproduce', 'reproduce']
+    issue_description: ['description', 'details', 'body', 'explain', 'steps_to_reproduce', 'reproduce'],
+    country: ['country', 'country_code', 'nation', 'nationality', 'country_name'],
   };
 
   function classifyField(element) {
@@ -321,6 +322,20 @@
         meta.candidates.push(...optionCandidates);
         meta.isFormFill = true;
       }
+    }
+
+    if (fieldType === 'country') {
+      try {
+        const locale = navigator.language || '';          
+        const regionCode = locale.split('-')[1];          
+        if (regionCode) {
+          const countryName = new Intl.DisplayNames(['en'], { type: 'region' }).of(regionCode);
+          if (countryName) {
+            meta.candidates.push({ value: countryName, source: 'Your browser locale', confidence: 0.85 });
+            meta.isFormFill = true;
+          }
+        }
+      } catch (e) { /* unsupported */ }
     }
 
     // ── Tab-dependent types: mark isFormFill so service-worker uses


### PR DESCRIPTION
## What
Adds `country` as a new form field type to `FORM_FIELD_PATTERNS`.

## How
- Matches fields with names/ids containing: `country`, `country_code`, 
  `nation`, `nationality`, `country_name`
- Detects the user's country locally from `navigator.language` 
  (e.g. "en-IN" → "India") using `Intl.DisplayNames`
- Uses try/catch consistent with the existing `timezone` block 
  which uses the same Intl API
- No API call needed — fully local detection

## Example
User with `navigator.language = "en-IN"` focusing a `name="country"` 
field will see "India" suggested with confidence 0.85