### PR TITLE
Fix Dark & White Mode storage and address password/token issues

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -107,8 +107,8 @@ async function generateSuggestions(data) {
       sessionIntent: await sessionTracker.getIntentContext()
     };
 
-    if (mergedContext.active_input_text && data.fieldName) {
-      if (contextCollector.isSensitiveInput(mergedContext.active_input_text, data.fieldName)) {
+    if (data.fieldName) {
+      if (contextCollector.isSensitiveInput(data.fieldName)) {
         return { success: true, reason: 'Sensitive input detected', suggestions: [] };
       }
     }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -318,24 +318,34 @@ async function toggleExtension() {
 const sign = document.getElementById('text');
 const outer = document.getElementById("outerbox");
 const inner = document.getElementById("innerbox");
-const text =document.getElementById("darkmode")
+const text = document.getElementById("darkmode");
 
-function changeText() {
-  if (sign.textContent == "X") {
+function applyDarkMode(enabled) {
+  if (enabled) {
     sign.textContent = "✔";
-    outer.classList.toggle("active");
-    inner.classList.toggle("active");
+    outer.classList.add("active");
+    inner.classList.add("active");
+    text.classList.add("active");
     document.body.classList.add('dark');
-    text.classList.toggle("active");
-    
-
   } else {
     sign.textContent = "X";
-    outer.classList.toggle("active");
-    inner.classList.toggle("active");
+    outer.classList.remove("active");
+    inner.classList.remove("active");
+    text.classList.remove("active");
     document.body.classList.remove('dark');
-     text.classList.toggle("active");
   }
+}
+
+// Restore persisted dark mode preference on popup open
+chrome.storage.local.get('darkMode', ({ darkMode }) => {
+  applyDarkMode(!!darkMode);
+});
+
+function changeText() {
+  const isDark = document.body.classList.contains('dark');
+  const next = !isDark;
+  applyDarkMode(next);
+  chrome.storage.local.set({ darkMode: next });
 }
 
 outer.addEventListener('click', changeText);

--- a/src/services/context-collector.js
+++ b/src/services/context-collector.js
@@ -294,7 +294,9 @@ class ContextCollector {
   /**
    * Check if input is sensitive
    */
-  isSensitiveInput(text, fieldName) {
+  isSensitiveInput(fieldName) {
+    if (!fieldName) return false;
+
     const sensitivePatterns = [
       /password/i, /passwd/i, /pwd/i,
       /credit[_\s-]?card/i, /cc[_\s-]?number/i,
@@ -305,8 +307,7 @@ class ContextCollector {
       /email/i, /e-mail/i
     ];
 
-    const combinedText = `${text} ${fieldName}`.toLowerCase();
-    return sensitivePatterns.some(pattern => pattern.test(combinedText));
+    return sensitivePatterns.some(pattern => pattern.test(fieldName.toLowerCase()));
   }
 }
 


### PR DESCRIPTION
This pull request introduces two main improvements: it simplifies and corrects the detection of sensitive input fields, and it enhances the dark mode toggle in the popup UI by persisting the user's preference. Below are the most important changes grouped by theme.

Sensitive input detection improvements:

* Refactored the `isSensitiveInput` method in `ContextCollector` to only use `fieldName` for matching sensitive patterns, removing the use of the input text and simplifying the logic. [[1]](diffhunk://#diff-91de33ac3b46c494fb2d05cd790b68544ebcb95d1bfe0c659f00f15ca90dc283L297-R299) [[2]](diffhunk://#diff-91de33ac3b46c494fb2d05cd790b68544ebcb95d1bfe0c659f00f15ca90dc283L308-R310)
* Updated `generateSuggestions` in `service-worker.js` to call the new `isSensitiveInput` signature, now passing only `fieldName`.

Dark mode toggle and persistence:

* Refactored the popup's dark mode logic: replaced toggle-based class changes with explicit add/remove, and added logic to persist the dark mode state using `chrome.storage.local`, restoring it when the popup is opened.