### PR TITLE
Removed non-existing sidebar function in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,12 +39,6 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "web_accessible_resources": [
-    {
-      "resources": ["src/sidebar/sidebar.html"],
-      "matches": ["<all_urls>"]
-    }
-  ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://api.groq.com" 
   }


### PR DESCRIPTION
The manifest referenced sidebar.html, but the file does not exist in the repository.

This PR removes the stale reference from manifest.json.