### PR TITLE
fix: remove non-existent sidebar.html from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,12 +39,6 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "web_accessible_resources": [
-    {
-      "resources": ["src/sidebar/sidebar.html"],
-      "matches": ["<all_urls>"]
-    }
-  ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://api.groq.com" 
   }


### PR DESCRIPTION
Resolves #66 

### Description
This PR removes the `web_accessible_resources` block from `manifest.json` referencing `src/sidebar/sidebar.html`, as this directory and file do not exist in the repository.

### Impact
- Resolves the Chrome developer warning regarding missing web-accessible resources when loading the unpacked extension.
- Cleans up dead configuration to avoid confusion for new contributors.