### PR TITLE
fix: avoid blocking suggestions for sensitive words in search

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -108,7 +108,7 @@ async function generateSuggestions(data) {
     };
 
     if (mergedContext.active_input_text && data.fieldName) {
-      if (contextCollector.isSensitiveInput(mergedContext.active_input_text, data.fieldName)) {
+      if (contextCollector.isSensitiveInput(data.fieldName)) {
         return { success: true, reason: 'Sensitive input detected', suggestions: [] };
       }
     }

--- a/src/services/context-collector.js
+++ b/src/services/context-collector.js
@@ -294,7 +294,7 @@ class ContextCollector {
   /**
    * Check if input is sensitive
    */
-  isSensitiveInput(text, fieldName) {
+  isSensitiveInput(fieldName) {
     const sensitivePatterns = [
       /password/i, /passwd/i, /pwd/i,
       /credit[_\s-]?card/i, /cc[_\s-]?number/i,
@@ -305,8 +305,11 @@ class ContextCollector {
       /email/i, /e-mail/i
     ];
 
-    const combinedText = `${text} ${fieldName}`.toLowerCase();
-    return sensitivePatterns.some(pattern => pattern.test(combinedText));
+    if (!fieldName) return false;
+
+    return sensitivePatterns.some(pattern =>
+      pattern.test(fieldName.toLowerCase())
+    );
   }
 }
 


### PR DESCRIPTION
Fixes #74

##Problem

Typing sensitive words such as password or token in a normal search field caused suggestions to be silently blocked.

The sensitive-input detection was checking both the user's typed text and the field name:

`${text} ${fieldName}`

This caused legitimate search queries containing words like password or token to be incorrectly classified as sensitive.

##Changes
-Updated isSensitiveInput() to check only the field name.
-Removed the user's typed input text from sensitive-pattern detection.
-Updated the caller in service-worker.js to pass only data.fieldName.
-Preserved detection for sensitive field names such as password, token, api-key, etc.

##Expected Behavior
-Searching for how to change my password in a normal search field → suggestions are shown.
-Searching for how to get an API token in a normal search field → suggestions are shown.
-A field named/type-associated with password or token → sensitive detection remains active.